### PR TITLE
chore: dependency updates and tests improvements

### DIFF
--- a/addons/osio-addon/pom.xml
+++ b/addons/osio-addon/pom.xml
@@ -11,11 +11,6 @@
 
   <artifactId>osio-addon</artifactId>
 
-  <properties>
-    <fabric8.version>3.0.3</fabric8.version>
-    <fabric8.maven.plugin.version>3.5.28</fabric8.maven.plugin.version>
-  </properties>
-
   <build>
     <resources>
       <resource>

--- a/addons/osio-addon/src/main/resources/io/fabric8/forge/generator/versions/versions.properties
+++ b/addons/osio-addon/src/main/resources/io/fabric8/forge/generator/versions/versions.properties
@@ -14,8 +14,8 @@
 #  permissions and limitations under the License.
 #
 
-io.fabric8/kubernetes-api = ${fabric8.version}
-io.fabric8/fabric8-maven-plugin = ${fabric8.maven.plugin.version}
+io.fabric8/kubernetes-api = ${version.fabric8.k8s.api}
+io.fabric8/fabric8-maven-plugin = ${version.fabric8.maven.plugin}
 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,10 +21,10 @@
     <version.furnace>2.27.0.Final</version.furnace>
     <version.swarm>2017.12.1</version.swarm>
     <version.jackson>2.9.3</version.jackson>
-    <version.fabric8.maven.plugin>3.1.92</version.fabric8.maven.plugin>
 
     <version.httpclient>4.3.5</version.httpclient>
     <version.github.api>1.90</version.github.api>
+    <version.fabric8.maven.plugin>3.5.28</version.fabric8.maven.plugin>
     <version.fabric8.openshift.client>3.1.2</version.fabric8.openshift.client>
     <version.fabric8.k8s.api>3.0.8</version.fabric8.k8s.api>
     <version.okhttp>3.9.0</version.okhttp>

--- a/pom.xml
+++ b/pom.xml
@@ -14,25 +14,27 @@
 
   <properties>
     <failOnMissingWebXml>false</failOnMissingWebXml>
-    <!-- Versions -->
-    <fabric8.maven.plugin.version>3.1.92</fabric8.maven.plugin.version>
-    <forge.version>3.8.1.Final</forge.version>
-    <forge.service.version>1.0.3.Final</forge.service.version>
-    <furnace.embedded.version>1.0.2.Final</furnace.embedded.version>
-    <furnace.version>2.27.0.Final</furnace.version>
-    <swarm.version>2017.11.0</swarm.version>
-    <version.com.fasterxml.jackson>2.7.7</version.com.fasterxml.jackson>
 
-    <version.org.apache.httpcomponents_httpclient>4.3.5</version.org.apache.httpcomponents_httpclient>
+    <version.forge>3.8.1.Final</version.forge>
+    <version.forge.service>1.0.3.Final</version.forge.service>
+    <version.furnace.embedded>1.0.2.Final</version.furnace.embedded>
+    <version.furnace>2.27.0.Final</version.furnace>
+    <version.swarm>2017.12.1</version.swarm>
+    <version.jackson>2.9.3</version.jackson>
+    <version.fabric8.maven.plugin>3.1.92</version.fabric8.maven.plugin>
+
+    <version.httpclient>4.3.5</version.httpclient>
+    <version.github.api>1.90</version.github.api>
+    <version.fabric8.openshift.client>3.1.2</version.fabric8.openshift.client>
+    <version.fabric8.k8s.api>3.0.8</version.fabric8.k8s.api>
+    <version.okhttp>3.9.0</version.okhttp>
+    <version.okio>1.13.0</version.okio>
+    <version.commons.io>2.6</version.commons.io>
+    <version.snakeyaml.>1.19</version.snakeyaml.>
+
     <version.arquillian_universe>1.1.13.5</version.arquillian_universe>
-    <version.org.kohsuke_github-api>1.85</version.org.kohsuke_github-api>
-    <version.io.fabric8_openshift-client>3.1.2</version.io.fabric8_openshift-client>
-    <version.io.fabric8_kubernetes-api>3.0.8</version.io.fabric8_kubernetes-api>
-    <version.com.squareup.okhttp>3.6.0</version.com.squareup.okhttp>
-    <version.com.squareup.okio>1.11.0</version.com.squareup.okio>
-    <version.org.jboss.arquillian.extension_arquillian-phantom-driver>1.2.1.Final
-    </version.org.jboss.arquillian.extension_arquillian-phantom-driver>
-    <version.org.assertj_assertj-core>3.4.1</version.org.assertj_assertj-core>
+    <version.arquillian.phantom.driver>1.2.1.Final</version.arquillian.phantom.driver>
+    <version.assertj.core>3.8.0</version.assertj.core>
   </properties>
 
   <modules>
@@ -124,24 +126,24 @@
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>bom-all</artifactId>
-        <version>${swarm.version}</version>
+        <version>${version.swarm}</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.jboss.forge</groupId>
         <artifactId>forge-service-core</artifactId>
-        <version>${forge.service.version}</version>
+        <version>${version.forge.service}</version>
       </dependency>
       <dependency>
          <groupId>org.jboss.forge.furnace</groupId>
          <artifactId>furnace-embedded</artifactId>
-         <version>${furnace.embedded.version}</version>
+         <version>${version.furnace.embedded}</version>
       </dependency>      
       <dependency>
         <groupId>org.jboss.forge</groupId>
         <artifactId>forge-bom</artifactId>
-        <version>${forge.version}</version>
+        <version>${version.forge}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -170,17 +172,17 @@
       <dependency>
         <groupId>org.kohsuke</groupId>
         <artifactId>github-api</artifactId>
-        <version>${version.org.kohsuke_github-api}</version>
+        <version>${version.github.api}</version>
       </dependency>
       <dependency>
         <groupId>io.fabric8</groupId>
         <artifactId>openshift-client</artifactId>
-        <version>${version.io.fabric8_openshift-client}</version>
+        <version>${version.fabric8.openshift.client}</version>
       </dependency>
       <dependency>
         <groupId>io.fabric8</groupId>
         <artifactId>kubernetes-api</artifactId>
-        <version>${version.io.fabric8_kubernetes-api}</version>
+        <version>${version.fabric8.k8s.api}</version>
       </dependency>
       <dependency>
         <groupId>org.arquillian</groupId>
@@ -192,69 +194,69 @@
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-yaml</artifactId>
-        <version>${version.com.fasterxml.jackson}</version>
+        <version>${version.jackson}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${version.com.fasterxml.jackson}</version>
+        <version>${version.jackson}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>${version.com.fasterxml.jackson}</version>
+        <version>${version.jackson}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>${version.com.fasterxml.jackson}</version>
+        <version>${version.jackson}</version>
       </dependency>
       <dependency>
         <groupId>com.squareup.okhttp3</groupId>
         <artifactId>okhttp-urlconnection</artifactId>
-        <version>${version.com.squareup.okhttp}</version>
+        <version>${version.okhttp}</version>
       </dependency>
       <dependency>
         <groupId>com.squareup.okhttp3</groupId>
         <artifactId>logging-interceptor</artifactId>
-        <version>${version.com.squareup.okhttp}</version>
+        <version>${version.okhttp}</version>
       </dependency>
       <dependency>
         <groupId>com.squareup.okhttp3</groupId>
         <artifactId>okhttp</artifactId>
-        <version>${version.com.squareup.okhttp}</version>
+        <version>${version.okhttp}</version>
       </dependency>
       <dependency>
         <groupId>com.squareup.okio</groupId>
         <artifactId>okio</artifactId>
-        <version>${version.com.squareup.okio}</version>
+        <version>${version.okio}</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.arquillian.extension</groupId>
         <artifactId>arquillian-phantom-driver</artifactId>
-        <version>${version.org.jboss.arquillian.extension_arquillian-phantom-driver}</version>
+        <version>${version.arquillian.phantom.driver}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
-        <version>${version.org.assertj_assertj-core}</version>
+        <version>${version.assertj.core}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>${version.org.apache.httpcomponents_httpclient}</version>
+        <version>${version.httpclient}</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.5</version>
+        <version>${version.commons.io}</version>
       </dependency>
       <dependency>
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
-        <version>1.18</version>
+        <version>${version.snakeyaml.}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -296,7 +298,7 @@
           <plugin>
             <groupId>io.fabric8</groupId>
             <artifactId>fabric8-maven-plugin</artifactId>
-            <version>${fabric8.maven.plugin.version}</version>
+            <version>${version.fabric8.maven.plugin}</version>
             <configuration>
               <generator>
                 <includes>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -17,7 +17,7 @@
       <plugin>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>wildfly-swarm-plugin</artifactId>
-        <version>${swarm.version}</version>
+        <version>${version.swarm}</version>
         <executions>
           <execution>
             <goals>
@@ -34,7 +34,7 @@
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>bom-all</artifactId>
-        <version>${swarm.version}</version>
+        <version>${version.swarm}</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -84,6 +84,12 @@
       <artifactId>infinispan</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <version>3.0.6</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.glassfish.tyrus</groupId>
       <artifactId>tyrus-client</artifactId>


### PR DESCRIPTION
- Bumped most of the dependencies besides Arquillian. It seems that Shrinkwrap Resolver changed how the dependencies are fetched and with newest version (3.0.x, vs 3.0.0-alpha-4 we have here) there are classloading issues while deploying tests archives. I will open issue about it
- Improved few tests by using `assertj` and `rest-assured`
- Aligned naming for `version.` properties in poms