### PR TITLE
fix(test): adds missing AbstractGitService

### DIFF
--- a/services/git-service-impl/src/test/java/io/fabric8/launcher/service/github/impl/GitHubServiceIT.java
+++ b/services/git-service-impl/src/test/java/io/fabric8/launcher/service/github/impl/GitHubServiceIT.java
@@ -1,28 +1,12 @@
 package io.fabric8.launcher.service.github.impl;
 
 
-import java.io.File;
-import java.net.HttpURLConnection;
-import java.net.URI;
-import java.net.URL;
-import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import javax.inject.Inject;
-import javax.ws.rs.core.UriBuilder;
-
 import io.fabric8.launcher.service.git.api.DuplicateHookException;
 import io.fabric8.launcher.service.git.api.GitHook;
 import io.fabric8.launcher.service.git.api.GitRepository;
 import io.fabric8.launcher.service.git.api.NoSuchHookException;
 import io.fabric8.launcher.service.git.api.NoSuchRepositoryException;
+import io.fabric8.launcher.service.git.impl.AbstractGitService;
 import io.fabric8.launcher.service.github.api.GitHubService;
 import io.fabric8.launcher.service.github.api.GitHubServiceFactory;
 import io.fabric8.launcher.service.github.api.GitHubWebhookEvent;
@@ -39,6 +23,22 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+import javax.ws.rs.core.UriBuilder;
+import java.io.File;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.jboss.shrinkwrap.resolver.api.maven.ScopeType.COMPILE;
@@ -85,8 +85,7 @@ public final class GitHubServiceIT {
         // Create deploy file
         WebArchive war = ShrinkWrap.create(WebArchive.class)
                 .addPackage(KohsukeGitHubServiceFactoryImpl.class.getPackage())
-                .addClass(GitHubTestCredentials.class)
-                .addClass(GitHubServiceSpi.class)
+                .addClasses(GitHubTestCredentials.class, GitHubServiceSpi.class, AbstractGitService.class)
                 // libraries will include all classes/interfaces from the API project.
                 .addAsLibraries(dependencies)
                 .addAsLibraries(testDependencies);


### PR DESCRIPTION
It seems that integration tests were broken. Hence I have two questions:

- why do we have them if we don't run them as a part of the build?
- shouldn't `mvn clean install` run them by default? What's the benefit of `it` profile? 