### PR TITLE
can also be an env property

### DIFF
--- a/addons/launcher-addon/pom.xml
+++ b/addons/launcher-addon/pom.xml
@@ -219,6 +219,10 @@
       <artifactId>arquillian-furnace-classpath</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.fabric8.launcher</groupId>
+      <artifactId>launcher-base</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/addons/launcher-addon/src/main/java/io/fabric8/launcher/addon/ui/booster/ChooseDeploymentTypeStep.java
+++ b/addons/launcher-addon/src/main/java/io/fabric8/launcher/addon/ui/booster/ChooseDeploymentTypeStep.java
@@ -7,6 +7,7 @@
 
 package io.fabric8.launcher.addon.ui.booster;
 
+import io.fabric8.launcher.base.EnvironmentSupport;
 import io.openshift.booster.catalog.DeploymentType;
 import io.openshift.booster.catalog.LauncherConfiguration;
 import org.jboss.forge.addon.ui.context.UIBuilder;
@@ -78,18 +79,14 @@ public class ChooseDeploymentTypeStep implements UIWizardStep {
         String openShiftClusterValue = openShiftCluster.getValue();
         attributeMap.put("OPENSHIFT_CLUSTER", openShiftClusterValue);
         // If a starter cluster was chosen, use the openshift-online-free catalog
+        String skipOpenshiftOnlineCatalogIndex = EnvironmentSupport.INSTANCE.getEnvVarOrSysProp("LAUNCHER_SKIP_OOF_CATALOG_INDEX", Boolean.FALSE.toString());
         if (deploymentTypeValue == DeploymentType.CD
-                && !getSkipOpenshiftOnlineFreeCatalogIndex()
+                && !Boolean.parseBoolean(skipOpenshiftOnlineCatalogIndex)
                 && openShiftClusterValue != null
                 && openShiftClusterValue.startsWith("starter")) {
             attributeMap.put(LauncherConfiguration.PropertyName.LAUNCHER_BOOSTER_CATALOG_REF, "openshift-online-free");
         }
         return null;
-    }
-
-    private static boolean getSkipOpenshiftOnlineFreeCatalogIndex() {
-        String name = "LAUNCHER_SKIP_OOF_CATALOG_INDEX";
-        return Boolean.parseBoolean(System.getProperty(name, System.getenv().getOrDefault(name, Boolean.FALSE.toString())));
     }
 
     @Override

--- a/addons/launcher-addon/src/main/java/io/fabric8/launcher/addon/ui/booster/ChooseDeploymentTypeStep.java
+++ b/addons/launcher-addon/src/main/java/io/fabric8/launcher/addon/ui/booster/ChooseDeploymentTypeStep.java
@@ -79,12 +79,17 @@ public class ChooseDeploymentTypeStep implements UIWizardStep {
         attributeMap.put("OPENSHIFT_CLUSTER", openShiftClusterValue);
         // If a starter cluster was chosen, use the openshift-online-free catalog
         if (deploymentTypeValue == DeploymentType.CD
-                && !Boolean.getBoolean("LAUNCHER_SKIP_OOF_CATALOG_INDEX")
+                && !getSkipOpenshiftOnlineFreeCatalogIndex()
                 && openShiftClusterValue != null
                 && openShiftClusterValue.startsWith("starter")) {
             attributeMap.put(LauncherConfiguration.PropertyName.LAUNCHER_BOOSTER_CATALOG_REF, "openshift-online-free");
         }
         return null;
+    }
+
+    private static boolean getSkipOpenshiftOnlineFreeCatalogIndex() {
+        String name = "LAUNCHER_SKIP_OOF_CATALOG_INDEX";
+        return Boolean.parseBoolean(System.getProperty(name, System.getenv().getOrDefault(name, Boolean.FALSE.toString())));
     }
 
     @Override


### PR DESCRIPTION
`Boolean.getBoolean` only uses the `System.getProperty`, but once deployed `"LAUNCHER_SKIP_OOF_CATALOG_INDEX"` is a environment variable