### PR TITLE
fix: proper github delete repository call

### DIFF
--- a/services/git-service-impl/src/main/java/io/fabric8/launcher/service/github/impl/KohsukeGitHubRepositoryImpl.java
+++ b/services/git-service-impl/src/main/java/io/fabric8/launcher/service/github/impl/KohsukeGitHubRepositoryImpl.java
@@ -26,8 +26,6 @@ class KohsukeGitHubRepositoryImpl implements GitRepository {
 
     private final GHRepository delegate;
 
-    private Logger log = Logger.getLogger(KohsukeGitHubRepositoryImpl.class.getName());
-
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
Currently deleting the repository results with `java.lang.ArrayIndexOutOfBoundsException: 1`.

```
java.lang.ArrayIndexOutOfBoundsException: 1

	at org.kohsuke.github.GitHub.getRepository(GitHub.java:443)
	at io.fabric8.launcher.service.github.impl.KohsukeGitHubServiceImpl.deleteRepository(KohsukeGitHubServiceImpl.java:338)
	at io.fabric8.launcher.service.github.impl.GitHubServiceIT.lambda$after$1(GitHubServiceIT.java:108)
	at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:184)
	at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175)
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1374)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
	at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:418)
	at io.fabric8.launcher.service.github.impl.GitHubServiceIT.after(GitHubServiceIT.java:108)
....
```