### PR TITLE
chore: updates arquillian-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
     <version.commons.io>2.6</version.commons.io>
     <version.snakeyaml>1.19</version.snakeyaml>
 
-    <version.assertj.core>3.8.0</version.assertj.core>
-    <version.git.rules>0.0.6</version.git.rules>
+    <version.assertj.core>3.9.0</version.assertj.core>
+    <version.git.rules>0.0.7</version.git.rules>
     <version.system.rules>1.17.0</version.system.rules>
     <version.immutables>2.5.5</version.immutables>
     <version.arquillian.core>1.2.0.Final</version.arquillian.core>

--- a/pom.xml
+++ b/pom.xml
@@ -34,11 +34,11 @@
     <version.commons.io>2.6</version.commons.io>
     <version.snakeyaml>1.19</version.snakeyaml>
 
-    <version.arquillian_universe>1.1.13.5</version.arquillian_universe>
     <version.assertj.core>3.8.0</version.assertj.core>
     <version.git.rules>0.0.6</version.git.rules>
     <version.system.rules>1.17.0</version.system.rules>
     <version.immutables>2.5.5</version.immutables>
+    <version.arquillian.core>1.2.0.Final</version.arquillian.core>
   </properties>
 
   <modules>
@@ -187,13 +187,6 @@
         <version>${version.fabric8.k8s.api}</version>
       </dependency>
       <dependency>
-        <groupId>org.arquillian</groupId>
-        <artifactId>arquillian-universe</artifactId>
-        <version>${version.arquillian_universe}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-yaml</artifactId>
         <version>${version.jackson}</version>
@@ -246,6 +239,12 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.jboss.arquillian.junit</groupId>
+        <artifactId>arquillian-junit-container</artifactId>
+        <version>${version.arquillian.core}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>org.arquillian.smart.testing</groupId>
         <artifactId>git-rules</artifactId>
         <version>${version.git.rules}</version>
@@ -295,7 +294,6 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- Brought in via Arquillian BOM, see dependencyManagement section above -->
     <dependency>
       <groupId>org.jboss.arquillian.junit</groupId>
       <artifactId>arquillian-junit-container</artifactId>

--- a/services/git-service-impl/src/test/resources/arquillian.xml
+++ b/services/git-service-impl/src/test/resources/arquillian.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://jboss.org/schema/arquillian"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian
+    http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+  <engine>
+    <property name="deploymentExportPath">target/deployment</property>
+  </engine>
+
+
+</arquillian>

--- a/web/src/test/java/io/fabric8/launcher/web/api/HealthResourceIT.java
+++ b/web/src/test/java/io/fabric8/launcher/web/api/HealthResourceIT.java
@@ -39,9 +39,6 @@ import java.net.URI;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-/**
- *
- */
 @RunWith(Arquillian.class)
 public class HealthResourceIT {
 

--- a/web/src/test/resources/arquillian.xml
+++ b/web/src/test/resources/arquillian.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://jboss.org/schema/arquillian"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian
+    http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+  <engine>
+    <property name="deploymentExportPath">target/deployment</property>
+  </engine>
+
+
+</arquillian>


### PR DESCRIPTION
I removed the `universe` BOM for two reasons:

- when updating to latest `1.2.0.0` it was causing integration tests to fail with very strange classpath issues, similar to this one [SWARM-1759](https://issues.jboss.org/browse/SWARM-1759)
- it wasn't actually used, as we were implicitly using `arquillian-junit-container` from there, so there was no actual benefit of using BOM at all

Bonuses:

- adds `arquillian.xml` with the configuration to export deployments - useful for troubleshooting
- bumps testing libraries