### PR TITLE
fix(tests): integration tests fixes

### DIFF
--- a/services/git-service-impl/src/main/java/io/fabric8/launcher/service/gitlab/impl/GitLabServiceImpl.java
+++ b/services/git-service-impl/src/main/java/io/fabric8/launcher/service/gitlab/impl/GitLabServiceImpl.java
@@ -1,18 +1,5 @@
 package io.fabric8.launcher.service.gitlab.impl;
 
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URI;
-import java.net.URL;
-import java.net.URLEncoder;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.Function;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.launcher.base.EnvironmentSupport;
@@ -35,6 +22,19 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
 
 /**
  * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
@@ -122,7 +122,7 @@ class GitLabServiceImpl extends AbstractGitService implements GitLabService {
     public Optional<GitRepository> getRepository(GitOrganization organization, String repositoryName) {
         Request request = request()
                 .get()
-                .url(GITLAB_URL + "/api/v4/groups/" + organization.getName() + "/projects?owned=true&search=" + encode(repositoryName))
+                .url(GITLAB_URL + "/api/v4/users/" + organization.getName() + "/projects?owned=true&search=" + encode(repositoryName))
                 .build();
         return execute(request, tree ->
         {

--- a/services/git-service-impl/src/test/java/io/fabric8/launcher/service/github/impl/GitHubServiceIT.java
+++ b/services/git-service-impl/src/test/java/io/fabric8/launcher/service/github/impl/GitHubServiceIT.java
@@ -1,24 +1,6 @@
 package io.fabric8.launcher.service.github.impl;
 
 
-import java.io.File;
-import java.net.HttpURLConnection;
-import java.net.URI;
-import java.net.URL;
-import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import javax.inject.Inject;
-import javax.ws.rs.core.UriBuilder;
-
 import io.fabric8.launcher.service.git.api.DuplicateHookException;
 import io.fabric8.launcher.service.git.api.GitHook;
 import io.fabric8.launcher.service.git.api.GitRepository;
@@ -42,6 +24,23 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+import javax.ws.rs.core.UriBuilder;
+import java.io.File;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -172,8 +171,8 @@ public final class GitHubServiceIT {
         GitUser user = service.getLoggedUser();
         assertThat(user).isNotNull();
         assertThat(user.getLogin()).isEqualTo(GitHubTestCredentials.getUsername());
-        assertThat(user.getEmail()).isNotNull();
     }
+
     @Test
     public void createGitHubRepository() {
         // given


### PR DESCRIPTION
Again, integration tests were not running successfully for me after latest changes on `master`. This revealed two issues:

- GitHub accounts not always have email available publicly - thus testing, or even assuming it's always there should not take place
- GitLab API for getting created project wasn't working when using `groups`. `users` resource should be used instead. This problem in fact leads to two follow-up questions
  - is our abstraction with organizations good enough? There is no notions of groups on GitHub nor organizations in GitLab and I'm not sure if we can treat them as the same concepts. Maybe the abstraction we are building is not good / needed here?
  - instead of plain http calls against GitLab maybe we can consider switching to one of the Java clients [[1]](https://github.com/timols/java-gitlab-api) [[2]](https://github.com/gmessner/gitlab4j-api)

Ah yeah, sorry for the imports again. Somehow the settings didn't persist. That's the last time.