### PR TITLE
Fix environment script

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ In a Unix-like environment you may like to create a `launcher-missioncontrol-env
 ```
 #!/bin/sh
 
-SCRIPT_DIR=$(dirname "$0")
+SCRIPT_DIR=$(dirname "$BASH_SOURCE")
 
 # Setting up authentication for the various services
 MSHIFT=$(minishift console --url)


### PR DESCRIPTION
When using 'source ...' the parameter $0 is not working.
We use $BASH_SOURCE to get the file location instead.