### PR TITLE
feat(jenkins): Add `pipelinePlatform` to `booster-catalog/runtimes` output

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <properties>
     <failOnMissingWebXml>false</failOnMissingWebXml>
 
-    <version.booster.catalog.service>23</version.booster.catalog.service>
+    <version.booster.catalog.service>24</version.booster.catalog.service>
     <version.forge>3.8.1.Final</version.forge>
     <version.forge.service>1.0.3.Final</version.forge.service>
     <version.furnace.embedded>1.0.2.Final</version.furnace.embedded>

--- a/web/src/main/java/io/fabric8/launcher/web/endpoints/BoosterCatalogEndpoint.java
+++ b/web/src/main/java/io/fabric8/launcher/web/endpoints/BoosterCatalogEndpoint.java
@@ -80,6 +80,7 @@ public class BoosterCatalogEndpoint {
             JsonObjectBuilder runtime = createObjectBuilder()
                     .add("id", r.getId())
                     .add("name", r.getName())
+                    .add("pipelinePlatform", r.getPipelinePlatform())
                     .add("icon", r.getIcon());
             for (Mission m : catalog.getMissions(withRuntime(r))) {
                 JsonArrayBuilder versions = createArrayBuilder();


### PR DESCRIPTION
Now using the booster-catalog-service version 24.

Fixes #79