### PR TITLE
fix(README): Fix environment script directory issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ In a Unix-like environment you may like to create a `launcher-missioncontrol-env
 ```
 #!/bin/sh
 
-SCRIPT_DIR=$(dirname "$BASH_SOURCE")
+SCRIPT_DIR=$(cd "$(dirname "$BASH_SOURCE")" ; pwd -P)
 
 # Setting up authentication for the various services
 MSHIFT=$(minishift console --url)


### PR DESCRIPTION
dirname "$BASH_SOURCE" is relative so it's always "./"