### PR TITLE
fix(github): Github token env is not mandatory

### DIFF
--- a/services/git-service-impl/src/main/java/io/fabric8/launcher/service/github/impl/KohsukeGitHubServiceFactoryImpl.java
+++ b/services/git-service-impl/src/main/java/io/fabric8/launcher/service/github/impl/KohsukeGitHubServiceFactoryImpl.java
@@ -68,12 +68,7 @@ public class KohsukeGitHubServiceFactoryImpl implements GitHubServiceFactory {
     @Override
     public Optional<Identity> getDefaultIdentity() {
         // Try using the provided Github token
-        return Optional.ofNullable(getToken())
-                .map(IdentityFactory::createFromToken);
+        String token = EnvironmentSupport.INSTANCE.getEnvVarOrSysProp(LAUNCHER_MISSIONCONTROL_GITHUB_TOKEN);
+        return Optional.ofNullable(token).map(IdentityFactory::createFromToken);
     }
-
-    private String getToken() {
-        return EnvironmentSupport.INSTANCE.getRequiredEnvVarOrSysProp(LAUNCHER_MISSIONCONTROL_GITHUB_TOKEN);
-    }
-
 }


### PR DESCRIPTION
Fixes a bug which required the default Github identity to be always set