### PR TITLE
Update "app.name" property for openshift extension  defined in arquillian.xml for any booster while creating project

### DIFF
--- a/addons/launcher-addon/src/main/java/io/fabric8/launcher/addon/preparers/ChangeArquillianConfigurationPreparer.java
+++ b/addons/launcher-addon/src/main/java/io/fabric8/launcher/addon/preparers/ChangeArquillianConfigurationPreparer.java
@@ -1,0 +1,95 @@
+package io.fabric8.launcher.addon.preparers;
+
+import io.fabric8.launcher.booster.catalog.rhoar.RhoarBooster;
+import io.fabric8.launcher.core.api.CreateProjectileContext;
+import io.fabric8.launcher.core.api.ProjectileContext;
+import io.fabric8.launcher.core.spi.ProjectilePreparer;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.enterprise.context.ApplicationScoped;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+
+@ApplicationScoped
+public class ChangeArquillianConfigurationPreparer implements ProjectilePreparer {
+
+   private Logger LOG = Logger.getLogger(ChangeArquillianConfigurationPreparer.class.getName());
+
+   @Override
+   public void prepare(Path projectPath, RhoarBooster booster, ProjectileContext context) {
+      if (!(context instanceof CreateProjectileContext)) {
+         return;
+      }
+      CreateProjectileContext createProjectileContext = (CreateProjectileContext) context;
+      updateArquillianConfiguration(projectPath, createProjectileContext.getArtifactId());
+   }
+
+   void updateArquillianConfiguration(Path projectPath, String property) {
+      try {
+         Files.walk(projectPath)
+            .filter(path -> path.endsWith("arquillian.xml"))
+            .forEach(path -> prepareArquillianConfig(path, property));
+      } catch (IOException e) {
+         throw new UncheckedIOException("Error while traversing project " + projectPath, e);
+      }
+   }
+
+   private NodeList getNodeList(Document document, String qualifier, String propertyName) {
+      if (document != null) {
+         XPath xpath = XPathFactory.newInstance().newXPath();
+         final String expression =
+            "/arquillian/extension[@qualifier='" + qualifier + "']/property[@name='" + propertyName + "']";
+         try {
+            return
+               (NodeList) xpath.evaluate(expression, document, XPathConstants.NODESET);
+         } catch (XPathExpressionException e) {
+            LOG.log(Level.WARNING,
+               "Error while evaluating xpath expression for `" + expression + "`");
+         }
+      }
+      return null;
+   }
+
+   private Document parseAsXml(File file) {
+      try {
+         DocumentBuilder documentBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+         return documentBuilder.parse(file);
+      } catch (Exception e) {
+         LOG.log(Level.WARNING, "Failed to parse xml from file" + file.getAbsolutePath());
+      }
+      return null;
+   }
+
+   private void prepareArquillianConfig(Path path, String propertyValue) {
+      final Document document = parseAsXml(path.toFile());
+      NodeList nodes = getNodeList(document, "openshift", "app.name");
+      if (nodes != null) {
+         for (int idx = 0; idx < nodes.getLength(); idx++) {
+            nodes.item(idx).setTextContent(propertyValue);
+         }
+
+         try {
+            Transformer xformer = TransformerFactory.newInstance().newTransformer();
+            xformer.transform(new DOMSource(document), new StreamResult(path.toFile()));
+         } catch (TransformerException e) {
+            LOG.log(Level.WARNING, "Failed to update configuration for arquillian in " + path.toAbsolutePath(), e);
+         }
+      }
+   }
+}

--- a/addons/launcher-addon/src/test/java/io/fabric8/launcher/addon/preparers/ChangeArquillianConfigurationPreparerTest.java
+++ b/addons/launcher-addon/src/test/java/io/fabric8/launcher/addon/preparers/ChangeArquillianConfigurationPreparerTest.java
@@ -1,0 +1,109 @@
+package io.fabric8.launcher.addon.preparers;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.assertj.core.api.Assertions.contentOf;
+
+public class ChangeArquillianConfigurationPreparerTest {
+
+   private static final String PROPERTY = "<property name=\"app.name\">foo.bar</property>";
+
+   @Rule
+   public TemporaryFolder folder = new TemporaryFolder();
+
+   @Before
+   public void setUp() throws IOException {
+      folder.newFolder("src", "test", "resources");
+   }
+
+   @Test
+   public void shouldUpdatePropertyAppNameForOpenshiftExtensionInArquillianXml() throws IOException {
+      // given
+      final Path destination =
+         Paths.get(folder.getRoot().getAbsolutePath(), "src", "test", "resources", "arquillian.xml");
+      final String resource = getClass().getResource("/configuration/arquillian.xml").getFile();
+      Files.copy(Paths.get(resource), destination);
+
+      final ChangeArquillianConfigurationPreparer configurationPreparer =
+         new ChangeArquillianConfigurationPreparer();
+
+      // when
+      configurationPreparer.updateArquillianConfiguration(Paths.get(folder.getRoot().getAbsolutePath()), "foo.bar");
+
+      // then
+      Assertions.assertThat(contentOf(destination.toFile()).contains(PROPERTY));
+   }
+
+   @Test
+   public void shouldNotUpdatePropertyAppNameForAnyOtherExtensionInArquillianXml() throws IOException {
+      // given
+      final Path destination =
+         Paths.get(folder.getRoot().getAbsolutePath(), "src", "test", "resources", "arquillian.xml");
+      final String resource = getClass().getResource("/configuration/arquillian.xml").getFile();
+      Files.copy(Paths.get(resource), destination);
+
+      final ChangeArquillianConfigurationPreparer configurationPreparer =
+         new ChangeArquillianConfigurationPreparer();
+
+      // when
+      configurationPreparer.updateArquillianConfiguration(Paths.get(folder.getRoot().getAbsolutePath()), "foo.bar");
+
+      // then
+      Assertions.assertThat(contentOf(destination.toFile()).contains("<property name=\"app.name\">backend</property>"));
+   }
+
+   @Test
+   public void shouldUpdatePropertyAppNameForOpenshiftExtensionInAllAvailableArquillianXml() throws IOException {
+      // given
+      folder.newFolder("impl", "src", "test", "resources");
+
+      final Path destination1 =
+         Paths.get(folder.getRoot().getAbsolutePath(), "src", "test", "resources", "arquillian.xml");
+      final Path destination2 =
+         Paths.get(folder.getRoot().getAbsolutePath(), "impl", "src", "test", "resources", "arquillian.xml");
+      final String resource = getClass().getResource("/configuration/arquillian.xml").getFile();
+
+      Files.copy(Paths.get(resource), destination1);
+      Files.copy(Paths.get(resource), destination2);
+
+      final ChangeArquillianConfigurationPreparer configurationPreparer =
+         new ChangeArquillianConfigurationPreparer();
+
+      // when
+      configurationPreparer.updateArquillianConfiguration(Paths.get(folder.getRoot().getAbsolutePath()), "foo.bar");
+
+      // then
+      Assertions.assertThat(contentOf(destination1.toFile()).contains(PROPERTY));
+      Assertions.assertThat(contentOf(destination2.toFile()).contains(PROPERTY));
+   }
+
+   @Test
+   public void shouldNotFailIfProjectDoesNotContainArquillianXml() throws IOException {
+      // given
+      final ChangeArquillianConfigurationPreparer configurationPreparer =
+         new ChangeArquillianConfigurationPreparer();
+
+      // when
+      configurationPreparer.updateArquillianConfiguration(Paths.get(folder.getRoot().getAbsolutePath()), "foo.bar");
+   }
+
+   @Test
+   public void shouldNotFailIfProjectContainEmptyArquillianXml() throws IOException {
+      // given
+      folder.newFile("src/test/resources/arquillian.xml");
+
+      final ChangeArquillianConfigurationPreparer configurationPreparer =
+         new ChangeArquillianConfigurationPreparer();
+
+      // when
+      configurationPreparer.updateArquillianConfiguration(Paths.get(folder.getRoot().getAbsolutePath()), "foo.bar");
+   }
+}

--- a/addons/launcher-addon/src/test/resources/configuration/arquillian.xml
+++ b/addons/launcher-addon/src/test/resources/configuration/arquillian.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://jboss.org/schema/arquillian"
+    xsi:schemaLocation="http://jboss.org/schema/arquillian
+    http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+  <engine>
+    <property name="deploymentExportPath">target/deployment</property>
+  </engine>
+
+  <extension qualifier="openshift">
+    <property name="app.name">launcher</property>
+  </extension>
+
+  <extension qualifier="docker">
+    <property name="app.name">backend</property>
+  </extension>
+
+  <container qualifier="daemon" default="true">
+    <configuration>
+      <property name="javaVmArguments">-Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=n</property>
+    </configuration>
+  </container>
+
+</arquillian>


### PR DESCRIPTION
**Why?**
Boosters have a special profile which [defines system property](https://github.com/bartoszmajsak/wfswarm-booster-pipeline-test/blob/bartoszmajsak-patch-1/pom.xml#L195) called `app.name` set for integration tests execution (`failsafe`). This is customizable, as the user can name his project anyhow he wants while using quickstart wizard.

The same property is then used as a service name when injecting [`@RouteUrl`](https://github.com/bartoszmajsak/wfswarm-booster-pipeline-test/blob/d6d7bf39a848fffc678788ba865d8471f83a0e03/src/test/java/io/openshift/booster/OpenshiftIT.java#L43) in the integration test itself. This however, does not work in Che as the property is not recognized.

By assuming boosters have `app.name` defined in arquillian.xml something like
 ```xml
  <extension qualifier="openshift">
     <property name="app.name">project_artifact</property> // to make it workable by default in all 
      boosters
    </extension>
  ```
If launcher-backend is able to update project artifact in arquillian.xml while creating project, then cube can resolve [`@RouteUrl`](https://github.com/bartoszmajsak/wfswarm-booster-pipeline-test/blob/d6d7bf39a848fffc678788ba865d8471f83a0e03/src/test/java/io/openshift/booster/OpenshiftIT.java#L43) in the integration test from che as well once https://github.com/arquillian/arquillian-cube/issues/996 has been fixed.

**Changes proposed in PR**
 - Update of `<property name="app.name">project_artifact</property>` to `<property name="app.name">user_input</property>` for openshift extension
- Adds unit tests
