### PR TITLE
fix(GIT): Make getRepository contract uniform across git providers

### DIFF
--- a/services/git-service-api/src/main/java/io/fabric8/launcher/service/git/api/GitService.java
+++ b/services/git-service-api/src/main/java/io/fabric8/launcher/service/git/api/GitService.java
@@ -65,9 +65,14 @@ public interface GitService {
     GitUser getLoggedUser();
 
     /**
+     * Get a repository:
+     *  - by its repository full name {owner}/{name}
+     *  - by its repository name, in which case it will look for an owned repository
+     *
+     * @param name the repository full name or just its name
      * @return the {@link GitRepository} specified as an {@link Optional} nullable object
      */
-    Optional<GitRepository> getRepository(String repositoryName);
+    Optional<GitRepository> getRepository(String name);
 
     /**
      * @return the {@link GitRepository} specified as an {@link Optional} nullable object

--- a/services/git-service-impl/src/main/java/io/fabric8/launcher/service/bitbucket/impl/BitbucketServiceImpl.java
+++ b/services/git-service-impl/src/main/java/io/fabric8/launcher/service/bitbucket/impl/BitbucketServiceImpl.java
@@ -139,15 +139,15 @@ public class BitbucketServiceImpl extends AbstractGitService implements Bitbucke
     }
 
     @Override
-    public Optional<GitRepository> getRepository(final String repositoryName) {
-        if (repositoryName == null || repositoryName.isEmpty()) {
+    public Optional<GitRepository> getRepository(final String name) {
+        if (name == null || name.isEmpty()) {
             throw new IllegalArgumentException("repositoryName must not be null or empty.");
         }
 
-        if (isValidGitRepositoryFullName(repositoryName)) {
-            return getRepositoryByFullName(repositoryName);
+        if (isValidGitRepositoryFullName(name)) {
+            return getRepositoryByFullName(name);
         } else {
-            return getRepositoryByFullName(createGitRepositoryFullName(getLoggedUser().getLogin(), repositoryName));
+            return getRepositoryByFullName(createGitRepositoryFullName(getLoggedUser().getLogin(), name));
         }
     }
 

--- a/services/git-service-impl/src/main/java/io/fabric8/launcher/service/github/impl/KohsukeGitHubServiceImpl.java
+++ b/services/git-service-impl/src/main/java/io/fabric8/launcher/service/github/impl/KohsukeGitHubServiceImpl.java
@@ -227,17 +227,17 @@ public final class KohsukeGitHubServiceImpl extends AbstractGitService implement
     }
 
     @Override
-    public Optional<GitRepository> getRepository(String repositoryName) {
+    public Optional<GitRepository> getRepository(String name) {
         // Precondition checks
-        if (repositoryName == null || repositoryName.isEmpty()) {
+        if (name == null || name.isEmpty()) {
             throw new IllegalArgumentException("repository name must be specified");
         }
         try {
-            if (repositoryName.contains("/")) {
-                String[] split = repositoryName.split("/");
+            if (name.contains("/")) {
+                String[] split = name.split("/");
                 return getRepository(ImmutableGitOrganization.of(split[0]), split[1]);
             } else {
-                return getRepository(ImmutableGitOrganization.of(delegate.getMyself().getLogin()), repositoryName);
+                return getRepository(ImmutableGitOrganization.of(delegate.getMyself().getLogin()), name);
             }
         } catch (IOException e) {
             return Optional.empty();

--- a/services/git-service-impl/src/main/java/io/fabric8/launcher/service/gitlab/impl/GitLabServiceImpl.java
+++ b/services/git-service-impl/src/main/java/io/fabric8/launcher/service/gitlab/impl/GitLabServiceImpl.java
@@ -117,27 +117,16 @@ class GitLabServiceImpl extends AbstractGitService implements GitLabService {
     }
 
     @Override
-    public Optional<GitRepository> getRepository(String repositoryName) {
+    public Optional<GitRepository> getRepository(String name) {
         // Precondition checks
-        if (repositoryName == null || repositoryName.isEmpty()) {
+        if (name == null || name.isEmpty()) {
             throw new IllegalArgumentException("repository name must be specified");
         }
-        if (repositoryName.contains("/")) {
-            String[] split = repositoryName.split("/");
+        if (name.contains("/")) {
+            String[] split = name.split("/");
             return getRepository(split[0], split[1]);
         } else {
-            Request request = request()
-                    .get()
-                    .url(GITLAB_URL + "/api/v4/projects?membership=true&search=" + encode(repositoryName))
-                    .build();
-            return execute(request, tree ->
-            {
-                Iterator<JsonNode> iterator = tree.iterator();
-                if (!iterator.hasNext()) {
-                    return null;
-                }
-                return readGitRepository(iterator.next());
-            });
+            return getRepository(getLoggedUser().getLogin(), name);
         }
     }
 

--- a/services/git-service-impl/src/test/resources/hoverfly/gl-simulation.json
+++ b/services/git-service-impl/src/test/resources/hoverfly/gl-simulation.json
@@ -729,7 +729,7 @@
     }, {
       "request" : {
         "path" : {
-          "exactMatch" : "/api/v4/projects"
+          "exactMatch" : "/api/v4/users/dipakpawar-test/projects"
         },
         "method" : {
           "exactMatch" : "GET"
@@ -741,7 +741,7 @@
           "exactMatch" : "https"
         },
         "query" : {
-          "exactMatch" : "membership=true&search=RepositoryDoesNotExist"
+          "exactMatch" : "owned=true&search=RepositoryDoesNotExist"
         },
         "body" : {
           "exactMatch" : ""


### PR DESCRIPTION
GitLab is now doing the same as GitHub and Bitbucket. 
It is now looking for an owned repository when only the name is given (instead of a memberOf repository)

Fixes #101