### PR TITLE
refactor(git): Make git service package more consistent

### DIFF
--- a/addons/osio-addon/src/test/java/io/fabric8/launcher/osio/steps/OpenShiftStepsTest.java
+++ b/addons/osio-addon/src/test/java/io/fabric8/launcher/osio/steps/OpenShiftStepsTest.java
@@ -20,7 +20,7 @@ import io.fabric8.launcher.osio.tenant.ImmutableTenant;
 import io.fabric8.launcher.osio.tenant.Tenant;
 import io.fabric8.launcher.service.git.api.GitRepository;
 import io.fabric8.launcher.service.git.api.ImmutableGitRepository;
-import io.fabric8.launcher.service.github.KohsukeGitHubServiceFactory;
+import io.fabric8.launcher.service.git.github.KohsukeGitHubServiceFactory;
 import io.fabric8.launcher.service.openshift.impl.fabric8.openshift.client.Fabric8OpenShiftServiceFactory;
 import io.fabric8.launcher.service.openshift.impl.fabric8.openshift.client.Fabric8OpenShiftServiceImpl;
 import org.junit.ClassRule;

--- a/core/core-impl/src/test/java/io/fabric8/launcher/core/impl/GitHubTestCredentials.java
+++ b/core/core-impl/src/test/java/io/fabric8/launcher/core/impl/GitHubTestCredentials.java
@@ -4,7 +4,7 @@ package io.fabric8.launcher.core.impl;
 import io.fabric8.launcher.base.EnvironmentSupport;
 import io.fabric8.launcher.base.identity.Identity;
 import io.fabric8.launcher.base.identity.IdentityFactory;
-import io.fabric8.launcher.service.github.api.GitHubEnvVarSysPropNames;
+import io.fabric8.launcher.service.git.github.api.GitHubEnvVarSysPropNames;
 
 /**
  * Used to obtain the GitHub credentials from the environment

--- a/services/git-service-api/src/main/java/io/fabric8/launcher/service/git/bitbucket/api/BitbucketEnvVarSysPropNames.java
+++ b/services/git-service-api/src/main/java/io/fabric8/launcher/service/git/bitbucket/api/BitbucketEnvVarSysPropNames.java
@@ -1,4 +1,4 @@
-package io.fabric8.launcher.service.bitbucket.api;
+package io.fabric8.launcher.service.git.bitbucket.api;
 
 /**
  * Contains names of environment variables or system properties

--- a/services/git-service-api/src/main/java/io/fabric8/launcher/service/git/bitbucket/api/BitbucketWebhookEvent.java
+++ b/services/git-service-api/src/main/java/io/fabric8/launcher/service/git/bitbucket/api/BitbucketWebhookEvent.java
@@ -1,4 +1,4 @@
-package io.fabric8.launcher.service.bitbucket.api;
+package io.fabric8.launcher.service.git.bitbucket.api;
 
 import java.util.Map;
 import java.util.Objects;

--- a/services/git-service-api/src/main/java/io/fabric8/launcher/service/git/github/api/GitHubEnvVarSysPropNames.java
+++ b/services/git-service-api/src/main/java/io/fabric8/launcher/service/git/github/api/GitHubEnvVarSysPropNames.java
@@ -1,4 +1,4 @@
-package io.fabric8.launcher.service.github.api;
+package io.fabric8.launcher.service.git.github.api;
 
 /**
  * Contains names of environment variables or system properties

--- a/services/git-service-api/src/main/java/io/fabric8/launcher/service/git/github/api/GitHubWebhookEvent.java
+++ b/services/git-service-api/src/main/java/io/fabric8/launcher/service/git/github/api/GitHubWebhookEvent.java
@@ -1,4 +1,4 @@
-package io.fabric8.launcher.service.github.api;
+package io.fabric8.launcher.service.git.github.api;
 
 public enum GitHubWebhookEvent {
     COMMIT_COMMENT,

--- a/services/git-service-api/src/main/java/io/fabric8/launcher/service/git/gitlab/api/GitLabEnvVarSysPropNames.java
+++ b/services/git-service-api/src/main/java/io/fabric8/launcher/service/git/gitlab/api/GitLabEnvVarSysPropNames.java
@@ -1,4 +1,4 @@
-package io.fabric8.launcher.service.gitlab.api;
+package io.fabric8.launcher.service.git.gitlab.api;
 
 /**
  * Contains names of environment variables or system properties

--- a/services/git-service-api/src/main/java/io/fabric8/launcher/service/git/gitlab/api/GitLabWebhookEvent.java
+++ b/services/git-service-api/src/main/java/io/fabric8/launcher/service/git/gitlab/api/GitLabWebhookEvent.java
@@ -1,4 +1,4 @@
-package io.fabric8.launcher.service.gitlab.api;
+package io.fabric8.launcher.service.git.gitlab.api;
 
 /**
  * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>

--- a/services/git-service-impl/src/main/java/io/fabric8/launcher/service/git/bitbucket/BitbucketService.java
+++ b/services/git-service-impl/src/main/java/io/fabric8/launcher/service/git/bitbucket/BitbucketService.java
@@ -1,4 +1,4 @@
-package io.fabric8.launcher.service.bitbucket;
+package io.fabric8.launcher.service.git.bitbucket;
 
 import java.net.URI;
 import java.net.URL;
@@ -33,9 +33,9 @@ import okhttp3.MediaType;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 
-import static io.fabric8.launcher.service.bitbucket.api.BitbucketWebhookEvent.ISSUE_COMMENT_CREATED;
-import static io.fabric8.launcher.service.bitbucket.api.BitbucketWebhookEvent.PULL_REQUEST_CREATED;
-import static io.fabric8.launcher.service.bitbucket.api.BitbucketWebhookEvent.REPO_PUSH;
+import static io.fabric8.launcher.service.git.bitbucket.api.BitbucketWebhookEvent.ISSUE_COMMENT_CREATED;
+import static io.fabric8.launcher.service.git.bitbucket.api.BitbucketWebhookEvent.PULL_REQUEST_CREATED;
+import static io.fabric8.launcher.service.git.bitbucket.api.BitbucketWebhookEvent.REPO_PUSH;
 import static io.fabric8.launcher.service.git.GitHelper.checkGitRepositoryFullNameArgument;
 import static io.fabric8.launcher.service.git.GitHelper.checkGitRepositoryNameArgument;
 import static io.fabric8.launcher.service.git.GitHelper.createGitRepositoryFullName;

--- a/services/git-service-impl/src/main/java/io/fabric8/launcher/service/git/bitbucket/BitbucketServiceFactory.java
+++ b/services/git-service-impl/src/main/java/io/fabric8/launcher/service/git/bitbucket/BitbucketServiceFactory.java
@@ -1,4 +1,4 @@
-package io.fabric8.launcher.service.bitbucket;
+package io.fabric8.launcher.service.git.bitbucket;
 
 import java.util.Optional;
 
@@ -7,12 +7,12 @@ import javax.enterprise.context.ApplicationScoped;
 import io.fabric8.launcher.base.EnvironmentSupport;
 import io.fabric8.launcher.base.identity.Identity;
 import io.fabric8.launcher.base.identity.IdentityFactory;
-import io.fabric8.launcher.service.bitbucket.api.BitbucketEnvVarSysPropNames;
+import io.fabric8.launcher.service.git.bitbucket.api.BitbucketEnvVarSysPropNames;
 import io.fabric8.launcher.service.git.api.GitServiceFactory;
 import io.fabric8.launcher.service.git.spi.GitProvider;
 
-import static io.fabric8.launcher.service.bitbucket.api.BitbucketEnvVarSysPropNames.LAUNCHER_MISSIONCONTROL_BITBUCKET_APPLICATION_PASSWORD;
-import static io.fabric8.launcher.service.bitbucket.api.BitbucketEnvVarSysPropNames.LAUNCHER_MISSIONCONTROL_BITBUCKET_USERNAME;
+import static io.fabric8.launcher.service.git.bitbucket.api.BitbucketEnvVarSysPropNames.LAUNCHER_MISSIONCONTROL_BITBUCKET_APPLICATION_PASSWORD;
+import static io.fabric8.launcher.service.git.bitbucket.api.BitbucketEnvVarSysPropNames.LAUNCHER_MISSIONCONTROL_BITBUCKET_USERNAME;
 import static io.fabric8.launcher.service.git.spi.GitProvider.GitProviderType.BITBUCKET;
 
 @ApplicationScoped

--- a/services/git-service-impl/src/main/java/io/fabric8/launcher/service/git/github/InvalidPathException.java
+++ b/services/git-service-impl/src/main/java/io/fabric8/launcher/service/git/github/InvalidPathException.java
@@ -1,4 +1,4 @@
-package io.fabric8.launcher.service.github;
+package io.fabric8.launcher.service.git.github;
 
 import java.net.URISyntaxException;
 

--- a/services/git-service-impl/src/main/java/io/fabric8/launcher/service/git/github/KohsukeGitHubRepository.java
+++ b/services/git-service-impl/src/main/java/io/fabric8/launcher/service/git/github/KohsukeGitHubRepository.java
@@ -1,4 +1,4 @@
-package io.fabric8.launcher.service.github;
+package io.fabric8.launcher.service.git.github;
 
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/services/git-service-impl/src/main/java/io/fabric8/launcher/service/git/github/KohsukeGitHubService.java
+++ b/services/git-service-impl/src/main/java/io/fabric8/launcher/service/git/github/KohsukeGitHubService.java
@@ -1,4 +1,4 @@
-package io.fabric8.launcher.service.github;
+package io.fabric8.launcher.service.git.github;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -28,7 +28,7 @@ import io.fabric8.launcher.service.git.api.ImmutableGitOrganization;
 import io.fabric8.launcher.service.git.api.ImmutableGitUser;
 import io.fabric8.launcher.service.git.api.NoSuchOrganizationException;
 import io.fabric8.launcher.service.git.api.NoSuchRepositoryException;
-import io.fabric8.launcher.service.github.api.GitHubWebhookEvent;
+import io.fabric8.launcher.service.git.github.api.GitHubWebhookEvent;
 import org.kohsuke.github.GHCreateRepositoryBuilder;
 import org.kohsuke.github.GHEvent;
 import org.kohsuke.github.GHException;

--- a/services/git-service-impl/src/main/java/io/fabric8/launcher/service/git/github/KohsukeGitHubServiceFactory.java
+++ b/services/git-service-impl/src/main/java/io/fabric8/launcher/service/git/github/KohsukeGitHubServiceFactory.java
@@ -1,4 +1,4 @@
-package io.fabric8.launcher.service.github;
+package io.fabric8.launcher.service.git.github;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -15,7 +15,7 @@ import io.fabric8.launcher.base.identity.UserPasswordIdentity;
 import io.fabric8.launcher.service.git.api.GitService;
 import io.fabric8.launcher.service.git.api.GitServiceFactory;
 import io.fabric8.launcher.service.git.spi.GitProvider;
-import io.fabric8.launcher.service.github.api.GitHubEnvVarSysPropNames;
+import io.fabric8.launcher.service.git.github.api.GitHubEnvVarSysPropNames;
 import okhttp3.OkHttpClient;
 import okhttp3.OkUrlFactory;
 import org.kohsuke.github.GitHub;
@@ -23,7 +23,7 @@ import org.kohsuke.github.GitHubBuilder;
 import org.kohsuke.github.extras.OkHttp3Connector;
 
 import static io.fabric8.launcher.service.git.spi.GitProvider.GitProviderType.GITHUB;
-import static io.fabric8.launcher.service.github.api.GitHubEnvVarSysPropNames.LAUNCHER_MISSIONCONTROL_GITHUB_TOKEN;
+import static io.fabric8.launcher.service.git.github.api.GitHubEnvVarSysPropNames.LAUNCHER_MISSIONCONTROL_GITHUB_TOKEN;
 
 /**
  * Implementation of the {@link GitServiceFactory}

--- a/services/git-service-impl/src/main/java/io/fabric8/launcher/service/git/github/KohsukeGitHubWebhook.java
+++ b/services/git-service-impl/src/main/java/io/fabric8/launcher/service/git/github/KohsukeGitHubWebhook.java
@@ -1,4 +1,4 @@
-package io.fabric8.launcher.service.github;
+package io.fabric8.launcher.service.git.github;
 
 import java.util.List;
 import java.util.Objects;

--- a/services/git-service-impl/src/main/java/io/fabric8/launcher/service/git/gitlab/GitLabService.java
+++ b/services/git-service-impl/src/main/java/io/fabric8/launcher/service/git/gitlab/GitLabService.java
@@ -1,4 +1,4 @@
-package io.fabric8.launcher.service.gitlab;
+package io.fabric8.launcher.service.git.gitlab;
 
 import java.net.URI;
 import java.net.URL;
@@ -28,7 +28,7 @@ import io.fabric8.launcher.service.git.api.ImmutableGitRepository;
 import io.fabric8.launcher.service.git.api.ImmutableGitUser;
 import io.fabric8.launcher.service.git.api.NoSuchOrganizationException;
 import io.fabric8.launcher.service.git.api.NoSuchRepositoryException;
-import io.fabric8.launcher.service.gitlab.api.GitLabEnvVarSysPropNames;
+import io.fabric8.launcher.service.git.gitlab.api.GitLabEnvVarSysPropNames;
 import okhttp3.MediaType;
 import okhttp3.Request;
 import okhttp3.RequestBody;
@@ -41,9 +41,9 @@ import static io.fabric8.launcher.service.git.GitHelper.createGitRepositoryFullN
 import static io.fabric8.launcher.service.git.GitHelper.encode;
 import static io.fabric8.launcher.service.git.GitHelper.execute;
 import static io.fabric8.launcher.service.git.GitHelper.isValidGitRepositoryFullName;
-import static io.fabric8.launcher.service.gitlab.api.GitLabWebhookEvent.ISSUES;
-import static io.fabric8.launcher.service.gitlab.api.GitLabWebhookEvent.MERGE_REQUESTS;
-import static io.fabric8.launcher.service.gitlab.api.GitLabWebhookEvent.PUSH;
+import static io.fabric8.launcher.service.git.gitlab.api.GitLabWebhookEvent.ISSUES;
+import static io.fabric8.launcher.service.git.gitlab.api.GitLabWebhookEvent.MERGE_REQUESTS;
+import static io.fabric8.launcher.service.git.gitlab.api.GitLabWebhookEvent.PUSH;
 import static java.util.Objects.requireNonNull;
 import static org.apache.commons.lang.StringUtils.isNotEmpty;
 

--- a/services/git-service-impl/src/main/java/io/fabric8/launcher/service/git/gitlab/GitLabServiceFactory.java
+++ b/services/git-service-impl/src/main/java/io/fabric8/launcher/service/git/gitlab/GitLabServiceFactory.java
@@ -1,4 +1,4 @@
-package io.fabric8.launcher.service.gitlab;
+package io.fabric8.launcher.service.git.gitlab;
 
 import java.util.Optional;
 
@@ -10,10 +10,10 @@ import io.fabric8.launcher.base.identity.IdentityFactory;
 import io.fabric8.launcher.base.identity.TokenIdentity;
 import io.fabric8.launcher.service.git.api.GitServiceFactory;
 import io.fabric8.launcher.service.git.spi.GitProvider;
-import io.fabric8.launcher.service.gitlab.api.GitLabEnvVarSysPropNames;
+import io.fabric8.launcher.service.git.gitlab.api.GitLabEnvVarSysPropNames;
 
 import static io.fabric8.launcher.service.git.spi.GitProvider.GitProviderType.GITLAB;
-import static io.fabric8.launcher.service.gitlab.api.GitLabEnvVarSysPropNames.LAUNCHER_MISSIONCONTROL_GITLAB_PRIVATE_TOKEN;
+import static io.fabric8.launcher.service.git.gitlab.api.GitLabEnvVarSysPropNames.LAUNCHER_MISSIONCONTROL_GITLAB_PRIVATE_TOKEN;
 
 /**
  * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>

--- a/services/git-service-impl/src/test/java/io/fabric8/launcher/service/git/bitbucket/BitbucketServiceIT.java
+++ b/services/git-service-impl/src/test/java/io/fabric8/launcher/service/git/bitbucket/BitbucketServiceIT.java
@@ -1,9 +1,9 @@
-package io.fabric8.launcher.service.bitbucket;
+package io.fabric8.launcher.service.git.bitbucket;
 
 
 import io.fabric8.launcher.base.EnvironmentSupport;
 import io.fabric8.launcher.base.test.hoverfly.LauncherPerTestHoverflyRule;
-import io.fabric8.launcher.service.bitbucket.api.BitbucketWebhookEvent;
+import io.fabric8.launcher.service.git.bitbucket.api.BitbucketWebhookEvent;
 import io.fabric8.launcher.service.git.AbstractGitServiceIT;
 import io.fabric8.launcher.service.git.api.ImmutableGitOrganization;
 import io.fabric8.launcher.service.git.spi.GitServiceSpi;
@@ -12,8 +12,8 @@ import org.junit.Rule;
 import org.junit.rules.RuleChain;
 
 import static io.fabric8.launcher.base.test.hoverfly.LauncherHoverflyEnvironment.createDefaultHoverflyEnvironment;
-import static io.fabric8.launcher.service.bitbucket.api.BitbucketEnvVarSysPropNames.LAUNCHER_MISSIONCONTROL_BITBUCKET_APPLICATION_PASSWORD;
-import static io.fabric8.launcher.service.bitbucket.api.BitbucketEnvVarSysPropNames.LAUNCHER_MISSIONCONTROL_BITBUCKET_USERNAME;
+import static io.fabric8.launcher.service.git.bitbucket.api.BitbucketEnvVarSysPropNames.LAUNCHER_MISSIONCONTROL_BITBUCKET_APPLICATION_PASSWORD;
+import static io.fabric8.launcher.service.git.bitbucket.api.BitbucketEnvVarSysPropNames.LAUNCHER_MISSIONCONTROL_BITBUCKET_USERNAME;
 
 public class BitbucketServiceIT extends AbstractGitServiceIT {
 

--- a/services/git-service-impl/src/test/java/io/fabric8/launcher/service/git/github/GitHubServiceFactoryTest.java
+++ b/services/git-service-impl/src/test/java/io/fabric8/launcher/service/git/github/GitHubServiceFactoryTest.java
@@ -1,4 +1,4 @@
-package io.fabric8.launcher.service.github;
+package io.fabric8.launcher.service.git.github;
 
 import io.fabric8.launcher.base.identity.IdentityFactory;
 import io.fabric8.launcher.service.git.api.GitService;

--- a/services/git-service-impl/src/test/java/io/fabric8/launcher/service/git/github/GitHubServiceIT.java
+++ b/services/git-service-impl/src/test/java/io/fabric8/launcher/service/git/github/GitHubServiceIT.java
@@ -1,4 +1,4 @@
-package io.fabric8.launcher.service.github;
+package io.fabric8.launcher.service.git.github;
 
 import io.fabric8.launcher.base.EnvironmentSupport;
 import io.fabric8.launcher.base.test.hoverfly.LauncherPerTestHoverflyRule;
@@ -6,14 +6,14 @@ import io.fabric8.launcher.service.git.AbstractGitServiceIT;
 import io.fabric8.launcher.service.git.api.GitService;
 import io.fabric8.launcher.service.git.api.ImmutableGitOrganization;
 import io.fabric8.launcher.service.git.spi.GitServiceSpi;
-import io.fabric8.launcher.service.github.api.GitHubWebhookEvent;
+import io.fabric8.launcher.service.git.github.api.GitHubWebhookEvent;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.rules.RuleChain;
 
 import static io.fabric8.launcher.base.test.hoverfly.LauncherHoverflyEnvironment.createDefaultHoverflyEnvironment;
-import static io.fabric8.launcher.service.github.api.GitHubEnvVarSysPropNames.LAUNCHER_MISSIONCONTROL_GITHUB_TOKEN;
-import static io.fabric8.launcher.service.github.api.GitHubEnvVarSysPropNames.LAUNCHER_MISSIONCONTROL_GITHUB_USERNAME;
+import static io.fabric8.launcher.service.git.github.api.GitHubEnvVarSysPropNames.LAUNCHER_MISSIONCONTROL_GITHUB_TOKEN;
+import static io.fabric8.launcher.service.git.github.api.GitHubEnvVarSysPropNames.LAUNCHER_MISSIONCONTROL_GITHUB_USERNAME;
 
 
 /**

--- a/services/git-service-impl/src/test/java/io/fabric8/launcher/service/git/gitlab/GitLabServiceIT.java
+++ b/services/git-service-impl/src/test/java/io/fabric8/launcher/service/git/gitlab/GitLabServiceIT.java
@@ -1,18 +1,18 @@
-package io.fabric8.launcher.service.gitlab;
+package io.fabric8.launcher.service.git.gitlab;
 
 import io.fabric8.launcher.base.EnvironmentSupport;
 import io.fabric8.launcher.base.test.hoverfly.LauncherPerTestHoverflyRule;
 import io.fabric8.launcher.service.git.AbstractGitServiceIT;
 import io.fabric8.launcher.service.git.api.ImmutableGitOrganization;
 import io.fabric8.launcher.service.git.spi.GitServiceSpi;
-import io.fabric8.launcher.service.gitlab.api.GitLabWebhookEvent;
+import io.fabric8.launcher.service.git.gitlab.api.GitLabWebhookEvent;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.rules.RuleChain;
 
 import static io.fabric8.launcher.base.test.hoverfly.LauncherHoverflyEnvironment.createDefaultHoverflyEnvironment;
-import static io.fabric8.launcher.service.gitlab.api.GitLabEnvVarSysPropNames.LAUNCHER_MISSIONCONTROL_GITLAB_PRIVATE_TOKEN;
-import static io.fabric8.launcher.service.gitlab.api.GitLabEnvVarSysPropNames.LAUNCHER_MISSIONCONTROL_GITLAB_USERNAME;
+import static io.fabric8.launcher.service.git.gitlab.api.GitLabEnvVarSysPropNames.LAUNCHER_MISSIONCONTROL_GITLAB_PRIVATE_TOKEN;
+import static io.fabric8.launcher.service.git.gitlab.api.GitLabEnvVarSysPropNames.LAUNCHER_MISSIONCONTROL_GITLAB_USERNAME;
 
 public class GitLabServiceIT extends AbstractGitServiceIT {
 


### PR DESCRIPTION
For package consistency:
Move .service.github, .service.bitbucket, .. to .service.git.github, ...
In order to have service.openshift, service.git, ..., as single root packages for each services