### PR TITLE
Adding proper validation to the space path

### DIFF
--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/projectiles/OsioImportProjectileContext.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/projectiles/OsioImportProjectileContext.java
@@ -3,6 +3,7 @@ package io.fabric8.launcher.osio.projectiles;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.ws.rs.FormParam;
+import javax.validation.constraints.Size;
 
 public class OsioImportProjectileContext {
 
@@ -23,7 +24,11 @@ public class OsioImportProjectileContext {
 
     @FormParam("spacePath")
     @NotNull
-    @Pattern(message = "Space Path should start with a /", regexp = "\\/[a-zA-Z]*")
+    @Size(message = "Space Path must be in the range of 4 to 63 characters long", min = 5, max = 63)
+    @Pattern(message = "Space Path should start with a slash (/)."
+            + " must contain only letters, numbers, spaces, underscores (_) or hyphens (-)"
+            + " It cannot start or end with a space, an underscore or a hyphen.",
+            regexp = "\\/[a-zA-Z\\d][a-zA-Z\\d\\s_-]*[a-zA-Z\\d]$")
     private String spacePath;
 
     public String getGitOrganization() {


### PR DESCRIPTION
Space path name requires validation:

- Application name must contain only letters (uppercase and lowercase), numbers, hyphens, underscores.
- It can not start and end with hyphens, spaces or underscores.
- It should be minimum 4 characters long.
- It should be maximum 63 characters long.
- It should start with a forward slash.