### PR TITLE
Booster catalog endpoints now return the original `metadata` from the booster catalog itself.

### DIFF
--- a/base/src/main/java/io/fabric8/launcher/base/JsonUtils.java
+++ b/base/src/main/java/io/fabric8/launcher/base/JsonUtils.java
@@ -1,0 +1,84 @@
+package io.fabric8.launcher.base;
+
+import javax.json.JsonArrayBuilder;
+import javax.json.JsonObjectBuilder;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Map;
+
+import static javax.json.Json.createArrayBuilder;
+import static javax.json.Json.createObjectBuilder;
+
+public abstract class JsonUtils {
+
+    private JsonUtils() {
+    }
+
+    /**
+     * Converts a <code>Map</code> of type <code>&lt;String, Object&gt;</code>
+     * to a <code>JsonObject</code>. The values of the object can itself be
+     * objects, arrays or simple values
+     */
+    @SuppressWarnings("unchecked")
+    public static JsonObjectBuilder mapToJson(Map<String, Object> map) {
+        JsonObjectBuilder builder = createObjectBuilder();
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            if (entry.getValue() instanceof Map) {
+                builder.add(entry.getKey(), mapToJson((Map<String, Object>) entry.getValue()));
+            } else if (entry.getValue() instanceof Iterable) {
+                builder.add(entry.getKey(), listToJson((Iterable<Object>)entry.getValue()));
+            } else if (entry.getValue() == null) {
+                builder.addNull(entry.getKey());
+            } else if (entry.getValue() instanceof Boolean) {
+                builder.add(entry.getKey(), (Boolean)entry.getValue());
+            } else if (entry.getValue() instanceof Double) {
+                builder.add(entry.getKey(), (Double)entry.getValue());
+            } else if (entry.getValue() instanceof Long) {
+                builder.add(entry.getKey(), (Long)entry.getValue());
+            } else if (entry.getValue() instanceof Integer) {
+                builder.add(entry.getKey(), (Integer)entry.getValue());
+            } else if (entry.getValue() instanceof BigInteger) {
+                builder.add(entry.getKey(), (BigInteger)entry.getValue());
+            } else if (entry.getValue() instanceof BigDecimal) {
+                builder.add(entry.getKey(), (BigDecimal) entry.getValue());
+            } else {
+                builder.add(entry.getKey(), entry.getValue().toString());
+            }
+        }
+        return builder;
+    }
+
+    /**
+     * Converts any <code>Iterable</code> of type <code>&lt;Object&gt;</code>
+     * to a <code>JsonArray</code>. The items of the array can itself be objects,
+     * arrays or simple values
+     */
+    @SuppressWarnings("unchecked")
+    public static JsonArrayBuilder listToJson(Iterable<Object> list) {
+        JsonArrayBuilder builder = createArrayBuilder();
+        for (Object item : list) {
+            if (item instanceof Map) {
+                builder.add(mapToJson((Map<String, Object>) item));
+            } else if (item instanceof Iterable) {
+                builder.add(listToJson((Iterable<Object>)item));
+            } else if (item == null) {
+                builder.addNull();
+            } else if (item instanceof Boolean) {
+                builder.add((Boolean)item);
+            } else if (item instanceof Double) {
+                builder.add((Double)item);
+            } else if (item instanceof Long) {
+                builder.add((Long)item);
+            } else if (item instanceof Integer) {
+                builder.add((Integer)item);
+            } else if (item instanceof BigInteger) {
+                builder.add((BigInteger)item);
+            } else if (item instanceof BigDecimal) {
+                builder.add((BigDecimal) item);
+            } else {
+                builder.add(item.toString());
+            }
+        }
+        return builder;
+    }
+}

--- a/web/src/main/java/io/fabric8/launcher/web/endpoints/BoosterCatalogEndpoint.java
+++ b/web/src/main/java/io/fabric8/launcher/web/endpoints/BoosterCatalogEndpoint.java
@@ -1,7 +1,10 @@
 package io.fabric8.launcher.web.endpoints;
 
-import java.util.Objects;
-import java.util.Optional;
+import io.fabric8.launcher.booster.catalog.rhoar.Mission;
+import io.fabric8.launcher.booster.catalog.rhoar.RhoarBooster;
+import io.fabric8.launcher.booster.catalog.rhoar.RhoarBoosterCatalog;
+import io.fabric8.launcher.booster.catalog.rhoar.Runtime;
+import io.fabric8.launcher.booster.catalog.rhoar.Version;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -17,14 +20,12 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.Objects;
+import java.util.Optional;
 
-import io.fabric8.launcher.booster.catalog.rhoar.Mission;
-import io.fabric8.launcher.booster.catalog.rhoar.RhoarBooster;
-import io.fabric8.launcher.booster.catalog.rhoar.RhoarBoosterCatalog;
-import io.fabric8.launcher.booster.catalog.rhoar.Runtime;
-import io.fabric8.launcher.booster.catalog.rhoar.Version;
 import io.fabric8.launcher.core.api.catalog.BoosterCatalogFactory;
 
+import static io.fabric8.launcher.base.JsonUtils.mapToJson;
 import static io.fabric8.launcher.booster.catalog.rhoar.BoosterPredicates.withMission;
 import static io.fabric8.launcher.booster.catalog.rhoar.BoosterPredicates.withRuntime;
 import static javax.json.Json.createArrayBuilder;
@@ -50,11 +51,14 @@ public class BoosterCatalogEndpoint {
             JsonArrayBuilder runtimes = createArrayBuilder();
             JsonObjectBuilder mission = createObjectBuilder()
                     .add("id", m.getId())
-                    .add("name", m.getName())
-                    .add("suggested", m.isSuggested());
+                    .add("name", m.getName());
             if (m.getDescription() != null) {
                 mission.add("description", m.getDescription());
             }
+            if (m.getMetadata() != null && !m.getMetadata().isEmpty()) {
+                mission.add("metadata", mapToJson(m.getMetadata()));
+            }
+
             // Add all runtimes
             catalog.getRuntimes(withMission(m))
                     .stream()
@@ -79,16 +83,28 @@ public class BoosterCatalogEndpoint {
             JsonObjectBuilder runtime = createObjectBuilder()
                     .add("id", r.getId())
                     .add("name", r.getName())
-                    .add("pipelinePlatform", r.getPipelinePlatform())
                     .add("icon", r.getIcon());
+            if (r.getDescription() != null) {
+                runtime.add("description", r.getDescription());
+            }
+            if (r.getMetadata() != null && !r.getMetadata().isEmpty()) {
+                runtime.add("metadata", mapToJson(r.getMetadata()));
+            }
             for (Mission m : catalog.getMissions(withRuntime(r))) {
                 JsonArrayBuilder versions = createArrayBuilder();
                 JsonObjectBuilder mission = createObjectBuilder()
                         .add("id", m.getId());
-                for (Version version : catalog.getVersions(m, r)) {
-                    versions.add(createObjectBuilder()
-                                         .add("id", version.getId())
-                                         .add("name", version.getName()));
+                for (Version v : catalog.getVersions(m, r)) {
+                    JsonObjectBuilder version = createObjectBuilder()
+                                         .add("id", v.getId())
+                                         .add("name", v.getName());
+                    if (v.getDescription() != null) {
+                        version.add("description", v.getDescription());
+                    }
+                    if (v.getMetadata() != null && !v.getMetadata().isEmpty()) {
+                        version.add("metadata", mapToJson(v.getMetadata()));
+                    }
+                    versions.add(version);
                 }
                 mission.add("versions", versions);
                 missions.add(mission);
@@ -148,5 +164,4 @@ public class BoosterCatalogEndpoint {
         boosterCatalogFactory.waitForIndex();
         return Response.ok().build();
     }
-
 }

--- a/web/src/main/java/io/fabric8/launcher/web/endpoints/BoosterCatalogEndpoint.java
+++ b/web/src/main/java/io/fabric8/launcher/web/endpoints/BoosterCatalogEndpoint.java
@@ -132,9 +132,9 @@ public class BoosterCatalogEndpoint {
             booster.add("gitRepo", b.getGitRepo());
             booster.add("gitRef", b.getGitRef());
 
-            JsonArrayBuilder runsOn = createArrayBuilder();
-            b.getRunsOn().forEach(runsOn::add);
-            booster.add("runsOn", runsOn);
+            if (b.getMetadata() != null && !b.getMetadata().isEmpty()) {
+                booster.add("metadata", mapToJson(b.getMetadata()));
+            }
 
             return Response.ok(booster.build()).build();
         }).orElseThrow(NotFoundException::new);

--- a/web/src/test/java/io/fabric8/launcher/web/endpoints/BoosterCatalogEndpointIT.java
+++ b/web/src/test/java/io/fabric8/launcher/web/endpoints/BoosterCatalogEndpointIT.java
@@ -29,8 +29,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.Is.isA;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.not;
 
 @RunWith(Arquillian.class)
 @RunAsClient
@@ -59,8 +62,8 @@ public class BoosterCatalogEndpointIT extends BaseResourceIT {
         .when()
                 .get("/missions")
         .then()
-                .assertThat().statusCode(200);
-
+                .assertThat().statusCode(200)
+                .body("id", not(empty()));
     }
 
     @Test
@@ -70,7 +73,9 @@ public class BoosterCatalogEndpointIT extends BaseResourceIT {
         .when()
                 .get("/runtimes")
         .then()
-                .assertThat().statusCode(200);
+                .assertThat().statusCode(200)
+                .body("id", not(empty()))
+                .body("metadata.pipelinePlatform", hasItems("maven", "node"));
     }
 
 
@@ -87,7 +92,7 @@ public class BoosterCatalogEndpointIT extends BaseResourceIT {
                 .assertThat().statusCode(200)
                 .body("gitRepo", is("https://github.com/openshiftio-vertx-boosters/vertx-crud-booster"))
                 .body("gitRef", is("master"))
-                .body("runsOn", isA(List.class));
+                .body("metadata.runsOn", is("!starter"));
 
     }
 }


### PR DESCRIPTION
See fabric8-launcher/launcher-planning#120 and fabric8-launcher/launcher-planning#121