### PR TITLE
feat(memory): Change Dockerfile.deploy to use memory flags

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -11,7 +11,7 @@ USER jboss
 
 ENV AB_OFF true
 ENV JAVA_APP_JAR launcher-backend-swarm.jar
-ENV JAVA_OPTIONS -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Djava.net.preferIPv4Stack=true
+ENV JAVA_OPTIONS -Djava.net.preferIPv4Stack=true
 
 EXPOSE 8080
 EXPOSE 8443

--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -1,19 +1,19 @@
-FROM registry.centos.org/jboss/base-jdk:8
+FROM fabric8/java-jboss-openjdk8-jdk:1.4.0
 MAINTAINER Vasek Pavlin <vasek@redhat.com>
+
+USER root
+RUN yum -y -q install git &&\
+    yum clean all &&\
+    rm -rf /var/cache/yum &&\
+    git config --system user.name openshiftio-launchpad &&\
+    git config --system user.email obsidian-leadership@redhat.com
+USER jboss
+
+ENV AB_OFF true
+ENV JAVA_APP_JAR launcher-backend-swarm.jar
+ENV JAVA_OPTIONS -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap
 
 EXPOSE 8080
 EXPOSE 8443
 
-CMD ["sh", "-c", "java -Djava.net.preferIPv4Stack=true $JAVA_OPTS -jar launcher-backend-swarm.jar"]
-
-USER root
-RUN chgrp -R 0 /opt/jboss &&\
-    chmod -R g+rw /opt/jboss &&\
-    find /opt/jboss -type d -exec chmod g+x {} + &&\
-    yum -y -q install git &&\
-    yum clean all &&\
-    git config --system user.name jboss &&\
-    git config --system user.email jboss@localhost
-USER jboss
-
-COPY target/launcher-backend-swarm.jar ./
+ADD target/$JAVA_APP_JAR /deployments/

--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -11,7 +11,7 @@ USER jboss
 
 ENV AB_OFF true
 ENV JAVA_APP_JAR launcher-backend-swarm.jar
-ENV JAVA_OPTIONS -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap
+ENV JAVA_OPTIONS -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Djava.net.preferIPv4Stack=true
 
 EXPOSE 8080
 EXPOSE 8443

--- a/docker.sh
+++ b/docker.sh
@@ -49,7 +49,7 @@ if [[ $DO_BUILD -eq 1 ]]; then
     echo "Building image..."
     mkdir -p target
     cp web/target/launcher-backend-swarm.jar target/
-    docker build -q -t fabric8/launcher-backend -f Dockerfile.deploy .
+    docker build -t fabric8/launcher-backend -f Dockerfile.deploy .
 fi
 
 if [[ $DO_RUN -eq 1 ]]; then


### PR DESCRIPTION
Using `-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap` to adjust
the memory heap to what's defined in the pod. The parent docker image is now using the
`fabric8/java-jboss-openjdk8-jdk` image, which calculates the container restriction.

Based on https://developers.redhat.com/blog/2017/03/14/java-inside-docker/

See https://hub.docker.com/r/fabric8/java-jboss-openjdk8-jdk/ for more details about the parent Docker image

Needed for #224