### PR TITLE
fix(arquillian-preparer): insert 'app.name' property if not present in openshift extension

### DIFF
--- a/addons/launcher-addon/src/main/java/io/fabric8/launcher/addon/preparers/ChangeArquillianConfigurationPreparer.java
+++ b/addons/launcher-addon/src/main/java/io/fabric8/launcher/addon/preparers/ChangeArquillianConfigurationPreparer.java
@@ -1,5 +1,9 @@
 package io.fabric8.launcher.addon.preparers;
 
+import io.fabric8.launcher.booster.catalog.rhoar.RhoarBooster;
+import io.fabric8.launcher.core.api.CreateProjectileContext;
+import io.fabric8.launcher.core.api.ProjectileContext;
+import io.fabric8.launcher.core.spi.ProjectilePreparer;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -8,10 +12,10 @@ import java.nio.file.Path;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
-
 import javax.enterprise.context.ApplicationScoped;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
@@ -21,12 +25,9 @@ import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
-
-import io.fabric8.launcher.booster.catalog.rhoar.RhoarBooster;
-import io.fabric8.launcher.core.api.CreateProjectileContext;
-import io.fabric8.launcher.core.api.ProjectileContext;
-import io.fabric8.launcher.core.spi.ProjectilePreparer;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 @ApplicationScoped
@@ -52,22 +53,6 @@ public class ChangeArquillianConfigurationPreparer implements ProjectilePreparer
         }
     }
 
-    private NodeList getNodeList(Document document, String qualifier, String propertyName) {
-        if (document != null) {
-            XPath xpath = XPathFactory.newInstance().newXPath();
-            final String expression =
-                    "/arquillian/extension[@qualifier='" + qualifier + "']/property[@name='" + propertyName + "']";
-            try {
-                return
-                        (NodeList) xpath.evaluate(expression, document, XPathConstants.NODESET);
-            } catch (XPathExpressionException e) {
-                LOG.log(Level.WARNING,
-                        "Error while evaluating xpath expression for `" + expression + "`");
-            }
-        }
-        return null;
-    }
-
     private Document parseAsXml(File file) {
         try {
             DocumentBuilder documentBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
@@ -79,19 +64,61 @@ public class ChangeArquillianConfigurationPreparer implements ProjectilePreparer
     }
 
     private void prepareArquillianConfig(Path path, String propertyValue) {
-        final Document document = parseAsXml(path.toFile());
-        NodeList nodes = getNodeList(document, "openshift", "app.name");
-        if (nodes != null) {
-            for (int idx = 0; idx < nodes.getLength(); idx++) {
-                nodes.item(idx).setTextContent(propertyValue);
-            }
+       final Document document = parseAsXml(path.toFile());
+       NodeList nodes = getNodeList(document, "/arquillian/extension[@qualifier='openshift']/property[@name='app.name']");
+       if (nodes != null) {
+          if (nodes.getLength() > 0) {
+             nodes.item(0).setTextContent(propertyValue);
+          } else {
+             addPropertyToOpenshiftExtension(document, propertyValue);
+          }
+          removeWhiteSpaceNodes(document);
+       }
+       try {
+          Transformer xformer = TransformerFactory.newInstance().newTransformer();
+          xformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+          xformer.setOutputProperty(OutputKeys.INDENT, "yes");
+          xformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+          xformer.transform(new DOMSource(document), new StreamResult(path.toFile()));
+       } catch (TransformerException e) {
+          LOG.log(Level.WARNING, "Failed to update configuration for arquillian in " + path.toAbsolutePath(), e);
+       }
+    }
 
-            try {
-                Transformer xformer = TransformerFactory.newInstance().newTransformer();
-                xformer.transform(new DOMSource(document), new StreamResult(path.toFile()));
-            } catch (TransformerException e) {
-                LOG.log(Level.WARNING, "Failed to update configuration for arquillian in " + path.toAbsolutePath(), e);
-            }
-        }
+   private void removeWhiteSpaceNodes(Document document) {
+      NodeList nodeList = getNodeList(document, "//text()[normalize-space()='']");
+
+      if (nodeList != null) {
+         for (int i = 0; i < nodeList.getLength(); ++i) {
+            Node node = nodeList.item(i);
+            node.getParentNode().removeChild(node);
+         }
+      }
+   }
+
+   private void addPropertyToOpenshiftExtension(Document document, String propertyValue) {
+      NodeList nodes = getNodeList(document, "/arquillian/extension[@qualifier='openshift']");
+
+      if (nodes != null && nodes.getLength() > 0) {
+         final Element element = document.createElement("property");
+         element.setAttribute("name", "app.name");
+         element.setTextContent(propertyValue);
+
+         nodes.item(0).appendChild(element);
+      }
+   }
+
+   private NodeList getNodeList(Document document, String expression) {
+      if (document != null) {
+         XPath xpath = XPathFactory.newInstance().newXPath();
+         try {
+            return
+               (NodeList) xpath.evaluate(expression, document, XPathConstants.NODESET);
+         } catch (XPathExpressionException e) {
+            LOG.log(Level.WARNING,
+               "Error while evaluating xpath expression for `" + expression + "`");
+         }
+      }
+      return null;
     }
 }

--- a/addons/launcher-addon/src/test/java/io/fabric8/launcher/addon/preparers/ChangeArquillianConfigurationPreparerIT.java
+++ b/addons/launcher-addon/src/test/java/io/fabric8/launcher/addon/preparers/ChangeArquillianConfigurationPreparerIT.java
@@ -114,7 +114,7 @@ public class ChangeArquillianConfigurationPreparerIT {
       // then
       Assertions.assertThat(
          contentOf(Paths.get(rootPath.toString(), "integration-tests/src/test/resources/arquillian.xml").toFile())
-            .contains("<property name=\"app.name\">my-artifact-id</property>")).isFalse();
+            .contains("<property name=\"app.name\">my-artifact-id</property>")).isTrue();
    }
 
    private static class MyArquillianProjectileContext implements CreateProjectileContext {

--- a/addons/launcher-addon/src/test/java/io/fabric8/launcher/addon/preparers/ChangeArquillianConfigurationPreparerTest.java
+++ b/addons/launcher-addon/src/test/java/io/fabric8/launcher/addon/preparers/ChangeArquillianConfigurationPreparerTest.java
@@ -4,12 +4,12 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.contentOf;
 
 public class ChangeArquillianConfigurationPreparerTest {
@@ -39,7 +39,25 @@ public class ChangeArquillianConfigurationPreparerTest {
       configurationPreparer.updateArquillianConfiguration(Paths.get(folder.getRoot().getAbsolutePath()), "foo.bar");
 
       // then
-      Assertions.assertThat(contentOf(destination.toFile()).contains(PROPERTY));
+      assertThat(contentOf(destination.toFile()).contains(PROPERTY)).isTrue();
+   }
+
+   @Test
+   public void shouldAddPropertyAppNameIfNotPresentForOpenshiftExtensionInArquillianXml() throws IOException {
+      // given
+      final Path destination =
+         Paths.get(folder.getRoot().getAbsolutePath(), "src", "test", "resources", "arquillian.xml");
+      final String resource = getClass().getResource("/configuration/arquillian-without-app-name-property.xml").getFile();
+      Files.copy(Paths.get(resource), destination);
+
+      final ChangeArquillianConfigurationPreparer configurationPreparer =
+         new ChangeArquillianConfigurationPreparer();
+
+      // when
+      configurationPreparer.updateArquillianConfiguration(Paths.get(folder.getRoot().getAbsolutePath()), "foo.bar");
+
+      // then
+      assertThat(contentOf(destination.toFile()).contains(PROPERTY)).isTrue();
    }
 
    @Test
@@ -57,7 +75,7 @@ public class ChangeArquillianConfigurationPreparerTest {
       configurationPreparer.updateArquillianConfiguration(Paths.get(folder.getRoot().getAbsolutePath()), "foo.bar");
 
       // then
-      Assertions.assertThat(contentOf(destination.toFile()).contains("<property name=\"app.name\">backend</property>"));
+      assertThat(contentOf(destination.toFile()).contains("<property name=\"app.name\">backend</property>")).isTrue();
    }
 
    @Test
@@ -81,8 +99,8 @@ public class ChangeArquillianConfigurationPreparerTest {
       configurationPreparer.updateArquillianConfiguration(Paths.get(folder.getRoot().getAbsolutePath()), "foo.bar");
 
       // then
-      Assertions.assertThat(contentOf(destination1.toFile()).contains(PROPERTY));
-      Assertions.assertThat(contentOf(destination2.toFile()).contains(PROPERTY));
+      assertThat(contentOf(destination1.toFile()).contains(PROPERTY)).isTrue();
+      assertThat(contentOf(destination2.toFile()).contains(PROPERTY)).isTrue();
    }
 
    @Test

--- a/addons/launcher-addon/src/test/resources/configuration/arquillian-without-app-name-property.xml
+++ b/addons/launcher-addon/src/test/resources/configuration/arquillian-without-app-name-property.xml
@@ -1,0 +1,13 @@
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://jboss.org/schema/arquillian"
+    xsi:schemaLocation="http://jboss.org/schema/arquillian
+    http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+  <engine>
+    <property name="deploymentExportPath">target/deployment</property>
+  </engine>
+
+  <extension qualifier="openshift">
+    <property name="env.init.enabled">true</property>
+  </extension>
+
+</arquillian>


### PR DESCRIPTION
*Proposed Changes*
* Add `app.name` for `openshift` extension with application `artifactId` in  `arquillian.xml` with. Previously it was updating only if `app.name` is already present.
* Fix unit test.