### PR TITLE
fix(swagger): add projectName as required parameter

### DIFF
--- a/web/src/main/webapp/swagger.yaml
+++ b/web/src/main/webapp/swagger.yaml
@@ -683,6 +683,9 @@ paths:
                 gitRepository:
                   description: The Git Repository to push the code
                   type: string
+                projectName:
+                  description: The name of the project to create
+                  type: string
               required:
                 - missionId
   /osio/import:


### PR DESCRIPTION
currently for `/osio/launch`  endpoint `projectName` is missing which is required parameter. Updated swagger doc accordingly