### PR TITLE
fix: ensure create jenkins config take github organization name if exist

### DIFF
--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioMissionControl.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioMissionControl.java
@@ -93,12 +93,14 @@ public class OsioMissionControl implements MissionControl {
 
         final BuildConfig buildConfig = openShiftSteps.createBuildConfig(projectile, repository);
 
-        openShiftSteps.createJenkinsConfigMap(projectile, repository);
 
         // create webhook first so that push will trigger build
         gitSteps.createWebHooks(projectile, repository);
 
         gitSteps.pushToGitRepository(projectile, repository);
+
+        // Create jenkins config
+        openShiftSteps.createJenkinsConfigMap(projectile, repository);
 
         // Trigger the build in Openshift
         openShiftSteps.triggerBuild(projectile);

--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/steps/OpenShiftSteps.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/steps/OpenShiftSteps.java
@@ -73,6 +73,10 @@ public class OpenShiftSteps {
     public ConfigMap createJenkinsConfigMap(OsioProjectile projectile, GitRepository repository) {
         String namespace = tenant.getDefaultUserNamespace().getName();
         String gitOwnerName = gitService.getLoggedUser().getLogin();
+        String gitOrganizationName = projectile.getGitOrganization();
+        if (gitOrganizationName != null) {
+            gitOwnerName = gitOrganizationName;
+        }
         String gitRepoName = repository.getFullName().substring(repository.getFullName().indexOf('/') + 1);
         ConfigMap cm = openShiftService.getConfigMap(gitOwnerName, namespace).orElse(null);
         boolean update = true;


### PR DESCRIPTION
In new launcher experience jenkins config does not take git organization name only takes github user name and jenkins scan-organization scans github user space only.

fixes: #250 