### PR TITLE
chore(swarm): upgrade WildFly Swarm to 2018.4.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ rebel.xml
 
 # Hoverfly captured simulations
 **/hoverfly/captured
+
+# Generated when running WildFly Swarm 2018.1.x+
+audit.log

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <version.forge.service>1.0.3.Final</version.forge.service>
     <version.furnace.embedded>1.0.3.Final</version.furnace.embedded>
     <version.furnace>2.27.0.Final</version.furnace>
-    <version.swarm>2017.11.0</version.swarm>
+    <version.swarm>2018.4.1</version.swarm>
     <version.jackson>2.9.4</version.jackson>
 
     <version.httpclient>4.5.5</version.httpclient>


### PR DESCRIPTION
This updates the underlying WildFly libraries and allows us to keep up with the new WF Swarm features