### PR TITLE
fix(converter): Mission and Runtime parameters must be provided by the RhoarBoosterCatalog

### DIFF
--- a/web/src/main/java/io/fabric8/launcher/web/providers/LauncherParamConverterProvider.java
+++ b/web/src/main/java/io/fabric8/launcher/web/providers/LauncherParamConverterProvider.java
@@ -1,0 +1,40 @@
+package io.fabric8.launcher.web.providers;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import javax.ws.rs.ext.ParamConverter;
+import javax.ws.rs.ext.ParamConverterProvider;
+import javax.ws.rs.ext.Provider;
+
+import io.fabric8.launcher.booster.catalog.rhoar.Mission;
+import io.fabric8.launcher.booster.catalog.rhoar.Runtime;
+
+/**
+ * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
+ */
+@Provider
+@ApplicationScoped
+public class LauncherParamConverterProvider implements ParamConverterProvider {
+
+    // Cannot use constructor-type injection (gives NPE in CdiInjectorFactory)
+    @Inject
+    private Instance<MissionParamConverter> missionParamConverter;
+
+    // Cannot use constructor-type injection (gives NPE in CdiInjectorFactory)
+    @Inject
+    private Instance<RuntimeParamConverter> runtimeParamConverter;
+
+    @Override
+    public <T> ParamConverter<T> getConverter(Class<T> rawType, Type genericType, Annotation[] annotations) {
+        if (rawType == Mission.class) {
+            return (ParamConverter<T>) missionParamConverter.get();
+        } else if (rawType == Runtime.class) {
+            return (ParamConverter<T>) runtimeParamConverter.get();
+        }
+        return null;
+    }
+}

--- a/web/src/main/java/io/fabric8/launcher/web/providers/MissionParamConverter.java
+++ b/web/src/main/java/io/fabric8/launcher/web/providers/MissionParamConverter.java
@@ -1,0 +1,58 @@
+package io.fabric8.launcher.web.providers;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ParamConverter;
+
+import io.fabric8.launcher.booster.catalog.rhoar.Mission;
+import io.fabric8.launcher.booster.catalog.rhoar.RhoarBoosterCatalog;
+
+import static javax.json.Json.createArrayBuilder;
+import static javax.json.Json.createObjectBuilder;
+
+/**
+ * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
+ */
+@ApplicationScoped
+public class MissionParamConverter implements ParamConverter<Mission> {
+
+    // Cannot use constructor-type injection (gives NPE in CdiInjectorFactory)
+    @Inject
+    private Instance<RhoarBoosterCatalog> catalogInstance;
+
+    @Override
+    public Mission fromString(final String missionId) {
+        if (missionId == null) {
+            throw new IllegalArgumentException("Mission ID is required");
+        } else {
+            RhoarBoosterCatalog catalog = catalogInstance.get();
+            return catalog.getMissions().stream()
+                    .filter(mission -> mission.getId().equals(missionId))
+                    .findFirst()
+                    .orElseThrow(() -> {
+                        Response response = Response.status(Response.Status.BAD_REQUEST)
+                                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                                .entity(createArrayBuilder()
+                                                .add(createObjectBuilder()
+                                                             .add("message", "Mission does not exist: " + missionId))
+                                                .build())
+                                .build();
+                        return new WebApplicationException(response);
+                    });
+
+        }
+    }
+
+    @Override
+    public String toString(Mission mission) {
+        if (mission == null) {
+            throw new IllegalArgumentException("Mission is required");
+        }
+        return mission.getId();
+    }
+}

--- a/web/src/main/java/io/fabric8/launcher/web/providers/RuntimeParamConverter.java
+++ b/web/src/main/java/io/fabric8/launcher/web/providers/RuntimeParamConverter.java
@@ -1,0 +1,57 @@
+package io.fabric8.launcher.web.providers;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ParamConverter;
+
+import io.fabric8.launcher.booster.catalog.rhoar.RhoarBoosterCatalog;
+import io.fabric8.launcher.booster.catalog.rhoar.Runtime;
+
+import static javax.json.Json.createArrayBuilder;
+import static javax.json.Json.createObjectBuilder;
+
+/**
+ * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
+ */
+@ApplicationScoped
+public class RuntimeParamConverter implements ParamConverter<Runtime> {
+
+    // Cannot use constructor-type injection (gives NPE in CdiInjectorFactory)
+    @Inject
+    private Instance<RhoarBoosterCatalog> catalogInstance;
+
+    @Override
+    public Runtime fromString(String runtimeId) {
+        if (runtimeId == null) {
+            throw new IllegalArgumentException("Runtime ID is required");
+        } else {
+            RhoarBoosterCatalog catalog = catalogInstance.get();
+            return catalog.getRuntimes().stream()
+                    .filter(runtime -> runtime.getId().equals(runtimeId))
+                    .findFirst()
+                    .orElseThrow(() -> {
+                        Response response = Response.status(Response.Status.BAD_REQUEST)
+                                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                                .entity(createArrayBuilder()
+                                                .add(createObjectBuilder()
+                                                             .add("message", "Runtime does not exist: " + runtimeId))
+                                                .build())
+                                .build();
+                        return new WebApplicationException(response);
+                    });
+        }
+    }
+
+    @Override
+    public String toString(Runtime value) {
+        if (value == null) {
+            throw new IllegalArgumentException("Runtime is required");
+        }
+        return value.getId();
+    }
+}

--- a/web/src/test/java/io/fabric8/launcher/web/endpoints/LauncherParamConverterProviderIT.java
+++ b/web/src/test/java/io/fabric8/launcher/web/endpoints/LauncherParamConverterProviderIT.java
@@ -1,0 +1,126 @@
+package io.fabric8.launcher.web.endpoints;
+
+import java.net.URI;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.UriBuilder;
+
+import io.fabric8.launcher.booster.catalog.rhoar.Mission;
+import io.fabric8.launcher.booster.catalog.rhoar.Runtime;
+import io.fabric8.launcher.web.Deployments;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.specification.RequestSpecification;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class LauncherParamConverterProviderIT {
+
+    @ArquillianResource
+    URI deploymentUri;
+
+    public RequestSpecification configureEndpoint() {
+        return new RequestSpecBuilder().setBaseUri(UriBuilder.fromUri(deploymentUri).path("api").path("converters").build()).build();
+    }
+
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return Deployments.createDeployment().addClass(RhoarBoosterEndpoint.class);
+    }
+
+    @Before
+    public void wait_until_catalog_is_indexed() {
+        given()
+                .spec(new RequestSpecBuilder().setBaseUri(UriBuilder.fromUri(deploymentUri).path("api").path("booster-catalog").build()).build())
+                .when()
+                .get("/wait")
+                .then()
+                .assertThat().statusCode(200);
+
+    }
+
+    @Test
+    public void should_convert_mission() {
+        given()
+                .spec(configureEndpoint())
+                .queryParam("id", "crud")
+                .when()
+                .get("/mission")
+                .then()
+                .assertThat().statusCode(200)
+                .body(containsString("CRUD"));
+    }
+
+    @Test
+    public void should_convert_runtime() {
+        given()
+                .spec(configureEndpoint())
+                .queryParam("id", "vert.x")
+                .when()
+                .get("/runtime")
+                .then()
+                .assertThat().statusCode(200)
+                .body(containsString("Eclipse Vert.x"));
+
+    }
+
+    @Test
+    public void should_treat_unknown_missions_as_bad_request() {
+        given()
+                .spec(configureEndpoint())
+                .queryParam("id", "foo")
+                .when()
+                .get("/mission")
+                .then()
+                .assertThat().statusCode(400);
+
+    }
+
+    @Test
+    public void should_treat_unknown_runtimes_as_bad_request() {
+        given()
+                .spec(configureEndpoint())
+                .queryParam("id", "foo")
+                .when()
+                .get("/runtime")
+                .then()
+                .assertThat().statusCode(400);
+
+    }
+
+    @Path("/converters")
+    public static class RhoarBoosterEndpoint {
+
+        @GET
+        @Path("/mission")
+        @Produces(MediaType.TEXT_PLAIN)
+        public String getMission(@QueryParam("id") Mission mission) {
+            return mission.getName();
+        }
+
+        @GET
+        @Path("/runtime")
+        @Produces(MediaType.TEXT_PLAIN)
+        public String getMission(@QueryParam("id") Runtime runtime) {
+            return runtime.getName();
+        }
+    }
+}


### PR DESCRIPTION
When any JAX-RS parameter using Mission or Runtime is used, the instances must be queried from the RhoarBoosterCatalog,
otherwise JAX-RS will construct a new object that uses the ID only.

Not using the original object will produce some unexpected results (see ReadmePreparer), where Mission.getName() returns the Mission ID.
This converter also validates if the Mission and Runtime exist in the catalog, otherwise a 400 - Bad request is thrown.