### PR TITLE
chore: show project version (commit hash) when starting up.

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -17,6 +17,12 @@
 
   <build>
     <finalName>launcher-backend</finalName>
+    <resources>
+      <resource>
+        <directory>${project.basedir}/src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <groupId>org.wildfly.swarm</groupId>

--- a/web/src/main/resources/modules/org/jboss/as/product/main/dir/META-INF/MANIFEST.MF
+++ b/web/src/main/resources/modules/org/jboss/as/product/main/dir/META-INF/MANIFEST.MF
@@ -1,0 +1,2 @@
+JBoss-Product-Release-Name: Fabric8 Launcher
+JBoss-Product-Release-Version: ${buildNumber}

--- a/web/src/main/resources/modules/org/jboss/as/product/main/module.xml
+++ b/web/src/main/resources/modules/org/jboss/as/product/main/module.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.product" slot="main">
+
+  <properties>
+    <property name="jboss.api" value="private"/>
+  </properties>
+
+  <resources>
+    <resource-root path="dir"/>
+    <!-- Insert resources here -->
+  </resources>
+
+  <dependencies>
+  </dependencies>
+</module>


### PR DESCRIPTION
It displays the following output:

```
2018-04-17 16:19:26,755 INFO  [org.jboss.as] (MSC service thread 1-8) WFLYSRV0049: Fabric8 Launcher ca6ff049b269731d162b2894a85f3f27e4139c1c (WildFly Core 3.0.8.Final) starting
```

Fixes #312