### PR TITLE
feat(openshift): /services/openshift now returns a richer information about the available clusters

### DIFF
--- a/services/openshift-service-api/src/main/java/io/fabric8/launcher/service/openshift/api/OpenShiftCluster.java
+++ b/services/openshift-service-api/src/main/java/io/fabric8/launcher/service/openshift/api/OpenShiftCluster.java
@@ -1,5 +1,7 @@
 package io.fabric8.launcher.service.openshift.api;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 /**
  * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
  */
@@ -31,10 +33,12 @@ public class OpenShiftCluster {
         return type;
     }
 
+    @JsonIgnore
     public String getApiUrl() {
         return apiUrl;
     }
 
+    @JsonIgnore
     public String getConsoleUrl() {
         return consoleUrl;
     }

--- a/web/src/main/webapp/swagger.yaml
+++ b/web/src/main/webapp/swagger.yaml
@@ -928,12 +928,6 @@ components:
         id:
           type: string
           description: The cluster ID
-        apiUrl:
-          type: string
-          description: The cluster API URL
-        consoleUrl:
-          type: string
-          description: The cluster console URL
         type:
           type: string
           description: 'The cluster type (can be starter, pro)'

--- a/web/src/main/webapp/swagger.yaml
+++ b/web/src/main/webapp/swagger.yaml
@@ -189,7 +189,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Cluster'
+                  $ref: '#/components/schemas/ClusterVerified'
   /services/openshift/clusters/all:
     get:
       summary: Returns all clusters
@@ -928,9 +928,26 @@ components:
         id:
           type: string
           description: The cluster ID
+        apiUrl:
+          type: string
+          description: The cluster API URL
+        consoleUrl:
+          type: string
+          description: The cluster console URL
         type:
           type: string
-          description: 'The cluster type (can be starter, pro, osio)'
+          description: 'The cluster type (can be starter, pro)'
+
+    ClusterVerified:
+      type: object
+      properties:
+        connected:
+          type: boolean
+          description: Is the cluster connected to the user account?
+        cluster:
+          description: The cluster itself
+          $ref: '#/components/schemas/Cluster'
+
     Pipeline:
       type: object
       properties:


### PR DESCRIPTION
/services/openshift:

```
[
    {
        "cluster": {
            "id": "openshift-v3",
            "type": "local"
        },
        "connected": true
    }
]
```

/services/openshift/clusters/all:

```
[
    {
        "id": "openshift-v3",
        "type": "local"
    }
]
```

Fixes #313