### PR TITLE
feat(gzip): Enable GZIP compression

### DIFF
--- a/web/src/main/java/io/fabric8/launcher/web/providers/gzip/GZipFilter.java
+++ b/web/src/main/java/io/fabric8/launcher/web/providers/gzip/GZipFilter.java
@@ -1,0 +1,60 @@
+package io.fabric8.launcher.web.providers.gzip;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
+ */
+@WebFilter(filterName = "GZipFilter", urlPatterns = "/*", asyncSupported = true)
+public class GZipFilter implements Filter {
+    @Override
+    public void init(FilterConfig filterConfig) {
+
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        // If not HttpServletRequest, ignore
+        if (!(request instanceof HttpServletRequest)) {
+            chain.doFilter(request, response);
+            return;
+        }
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+        if (acceptsGZipEncoding(httpRequest)) {
+            httpResponse.setHeader("Content-Encoding", "gzip");
+            try (GZipServletResponseWrapper gzipResponse =
+                         new GZipServletResponseWrapper(httpResponse)) {
+                chain.doFilter(request, gzipResponse);
+            }
+        } else {
+            chain.doFilter(request, response);
+        }
+
+    }
+
+    private boolean acceptsGZipEncoding(HttpServletRequest httpRequest) {
+        String acceptEncoding =
+                httpRequest.getHeader("Accept-Encoding");
+
+        return acceptEncoding != null &&
+                acceptEncoding.contains("gzip");
+    }
+
+
+    @Override
+    public void destroy() {
+
+    }
+}

--- a/web/src/main/java/io/fabric8/launcher/web/providers/gzip/GZipServletOutputStream.java
+++ b/web/src/main/java/io/fabric8/launcher/web/providers/gzip/GZipServletOutputStream.java
@@ -1,0 +1,57 @@
+package io.fabric8.launcher.web.providers.gzip;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.zip.GZIPOutputStream;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
+
+/**
+ * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
+ */
+class GZipServletOutputStream extends ServletOutputStream {
+
+    private GZIPOutputStream gzipOutputStream;
+
+    public GZipServletOutputStream(OutputStream output)
+            throws IOException {
+        super();
+        this.gzipOutputStream = new GZIPOutputStream(output);
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.gzipOutputStream.close();
+    }
+
+    @Override
+    public void flush() throws IOException {
+        this.gzipOutputStream.flush();
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+        this.gzipOutputStream.write(b);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        this.gzipOutputStream.write(b, off, len);
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        this.gzipOutputStream.write(b);
+    }
+
+    @Override
+    public boolean isReady() {
+        return true;
+    }
+
+    @Override
+    public void setWriteListener(WriteListener writeListener) {
+
+    }
+}

--- a/web/src/main/java/io/fabric8/launcher/web/providers/gzip/GZipServletResponseWrapper.java
+++ b/web/src/main/java/io/fabric8/launcher/web/providers/gzip/GZipServletResponseWrapper.java
@@ -1,0 +1,107 @@
+package io.fabric8.launcher.web.providers.gzip;
+
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
+
+/**
+ * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
+ */
+class GZipServletResponseWrapper extends HttpServletResponseWrapper implements AutoCloseable {
+    private GZipServletOutputStream gzipOutputStream = null;
+
+    private PrintWriter printWriter = null;
+
+    public GZipServletResponseWrapper(HttpServletResponse response) {
+        super(response);
+    }
+
+    @Override
+    public void close() throws IOException {
+
+        //PrintWriter.close does not throw exceptions.
+        //Hence no try-catch block.
+        if (this.printWriter != null) {
+            this.printWriter.close();
+        }
+
+        if (this.gzipOutputStream != null) {
+            this.gzipOutputStream.close();
+        }
+    }
+
+
+    /**
+     * Flush OutputStream or PrintWriter
+     *
+     * @throws IOException
+     */
+
+    @Override
+    public void flushBuffer() throws IOException {
+
+        //PrintWriter.flush() does not throw exception
+        if (this.printWriter != null) {
+            this.printWriter.flush();
+        }
+
+        IOException exception1 = null;
+        try {
+            if (this.gzipOutputStream != null) {
+                this.gzipOutputStream.flush();
+            }
+        } catch (IOException e) {
+            exception1 = e;
+        }
+
+        IOException exception2 = null;
+        try {
+            super.flushBuffer();
+        } catch (IOException e) {
+            exception2 = e;
+        }
+
+        if (exception1 != null) throw exception1;
+        if (exception2 != null) throw exception2;
+    }
+
+    @Override
+    public ServletOutputStream getOutputStream() throws IOException {
+        if (this.printWriter != null) {
+            throw new IllegalStateException(
+                    "PrintWriter obtained already - cannot get OutputStream");
+        }
+        if (this.gzipOutputStream == null) {
+            this.gzipOutputStream = new GZipServletOutputStream(
+                    getResponse().getOutputStream());
+        }
+        return this.gzipOutputStream;
+    }
+
+    @Override
+    public PrintWriter getWriter() throws IOException {
+        if (this.printWriter == null && this.gzipOutputStream != null) {
+            throw new IllegalStateException(
+                    "OutputStream obtained already - cannot get PrintWriter");
+        }
+        if (this.printWriter == null) {
+            this.gzipOutputStream = new GZipServletOutputStream(
+                    getResponse().getOutputStream());
+            this.printWriter = new PrintWriter(new OutputStreamWriter(
+                    this.gzipOutputStream, getResponse().getCharacterEncoding()));
+        }
+        return this.printWriter;
+    }
+
+
+    @Override
+    public void setContentLength(int len) {
+        //ignore, since content length of zipped content
+        //does not match content length of unzipped content.
+    }
+
+}


### PR DESCRIPTION
Why GZip Compress Content?
--------------------------
GZip compressing makes the data sent to the browser smaller. This speeds up the download. This is especially beneficial for mobile phones where internet bandwidth may be limited. GZip compressing content adds a CPU overhead on the server and browser, but it is still speeding up the total page load compared to not GZip compressing.

GZip HTTP Headers
-----------------
The browser includes the `Accept-Encoding` HTTP header in requests sent to an HTTP server (e.g. a Java web server). The content of the `Accept-Encoding` header tells what content encodings the browser can accept. If that header contains the value gzip in it, the browser can accept GZip compressed content. The server can then GZip compress the content sent back to the browser.

If the content sent back from the server is GZip compressed, the server includes the `Content-Encoding` HTTP header with the value gzip in the HTTP response. That way the browser knows that the content is GZip compressed.

Why a GZip Servlet Filter?
--------------------------
It is executed before anything else, so it can be used for any content exposed in this application

Measured Improvements
---------------------

- /api/booster-catalog/missions reduced from 3266 to 1202 bytes
- /api/services/jenkins/pipelines reduced from 9757 to 701 bytes

Fixes #331
