### PR TITLE
fix(git): make sure that git organization is use when creating the git

### DIFF
--- a/core/core-api/src/main/java/io/fabric8/launcher/core/api/projectiles/CreateProjectile.java
+++ b/core/core-api/src/main/java/io/fabric8/launcher/core/api/projectiles/CreateProjectile.java
@@ -23,10 +23,16 @@ public interface CreateProjectile extends Projectile {
     String getOpenShiftProjectName();
 
     /**
-     * @return The name to use in creating the new OpenShift project
+     * @return The name to use in creating the new Git projects
      */
     @Nullable
     String getGitRepositoryName();
+
+    /**
+     * @return The name to use for the location of the Git project
+     */
+    @Nullable
+    String getGitOrganization();
 
     @Value.Default
     default String getGitRepositoryDescription() {

--- a/core/core-impl/src/main/java/io/fabric8/launcher/core/impl/MissionControlImpl.java
+++ b/core/core-impl/src/main/java/io/fabric8/launcher/core/impl/MissionControlImpl.java
@@ -85,6 +85,7 @@ public class MissionControlImpl implements MissionControl {
             if (context instanceof LauncherProjectileContext) {
                 LauncherProjectileContext launcherContext = (LauncherProjectileContext) context;
                 builder.openShiftProjectName(launcherContext.getProjectName())
+                        .gitOrganization(launcherContext.getGitOrganization())
                         .gitRepositoryName(launcherContext.getGitRepository());
             }
             return builder.build();


### PR DESCRIPTION
### Why

In the new flow we can also specify which organisation we want to create the git repo

### Description

This fixes an issue

Closes could not find the issue

### Checklist

- [x] I followed the contribution [guidelines](https://raw.githubusercontent.com/fabric8-launcher/launcher-backend/master/CONTRIBUTING.md).
- [] I created an [issue](https://github.com/fabric8-launcher/launcher-backend/issues/new) and used it in the commit message.
- [x] I have built the project locally prior to submission with `mvn clean install`.
- [x] I kept a clean commit log (no unnecessary commits, no merge commits).
