### PR TITLE
feat(booster-catalog): Support filtering by a script expression

### DIFF
--- a/core/core-impl/src/test/java/io/fabric8/launcher/core/impl/catalog/ScriptingRhoarBoosterPredicateTest.java
+++ b/core/core-impl/src/test/java/io/fabric8/launcher/core/impl/catalog/ScriptingRhoarBoosterPredicateTest.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import io.fabric8.launcher.booster.catalog.rhoar.RhoarBooster;
 import org.junit.Test;
 
+import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -30,7 +31,7 @@ public class ScriptingRhoarBoosterPredicateTest {
     public void should_evaluate_metadata_to_true() {
         ScriptingRhoarBoosterPredicate predicate = new ScriptingRhoarBoosterPredicate("booster.metadata.istio");
         RhoarBooster booster = mock(RhoarBooster.class);
-        when(booster.getMetadata()).thenReturn(Collections.singletonMap("istio", "true"));
+        when(booster.getMetadata()).thenReturn(singletonMap("istio", "true"));
         assertThat(predicate.test(booster)).isTrue();
     }
 
@@ -38,8 +39,8 @@ public class ScriptingRhoarBoosterPredicateTest {
     public void should_evaluate_metadata_to_false() {
         ScriptingRhoarBoosterPredicate predicate = new ScriptingRhoarBoosterPredicate("booster.metadata.istio");
         RhoarBooster booster = mock(RhoarBooster.class);
-        when(booster.getMetadata()).thenReturn(Collections.singletonMap("istio", "true"));
-        assertThat(predicate.test(booster)).isTrue();
+        when(booster.getMetadata()).thenReturn(singletonMap("istio", "false"));
+        assertThat(predicate.test(booster)).isFalse();
     }
 
 }

--- a/core/core-impl/src/test/java/io/fabric8/launcher/core/impl/catalog/ScriptingRhoarBoosterPredicateTest.java
+++ b/core/core-impl/src/test/java/io/fabric8/launcher/core/impl/catalog/ScriptingRhoarBoosterPredicateTest.java
@@ -1,0 +1,45 @@
+package io.fabric8.launcher.core.impl.catalog;
+
+import java.util.Collections;
+
+import io.fabric8.launcher.booster.catalog.rhoar.RhoarBooster;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
+ */
+public class ScriptingRhoarBoosterPredicateTest {
+
+    @Test
+    public void should_evaluate_to_true() {
+        ScriptingRhoarBoosterPredicate predicate = new ScriptingRhoarBoosterPredicate("booster != null");
+        assertThat(predicate.test(mock(RhoarBooster.class))).isTrue();
+    }
+
+    @Test
+    public void should_evaluate_to_false() {
+        ScriptingRhoarBoosterPredicate predicate = new ScriptingRhoarBoosterPredicate("booster == null");
+        assertThat(predicate.test(mock(RhoarBooster.class))).isFalse();
+    }
+
+    @Test
+    public void should_evaluate_metadata_to_true() {
+        ScriptingRhoarBoosterPredicate predicate = new ScriptingRhoarBoosterPredicate("booster.metadata.istio");
+        RhoarBooster booster = mock(RhoarBooster.class);
+        when(booster.getMetadata()).thenReturn(Collections.singletonMap("istio", "true"));
+        assertThat(predicate.test(booster)).isTrue();
+    }
+
+    @Test
+    public void should_evaluate_metadata_to_false() {
+        ScriptingRhoarBoosterPredicate predicate = new ScriptingRhoarBoosterPredicate("booster.metadata.istio");
+        RhoarBooster booster = mock(RhoarBooster.class);
+        when(booster.getMetadata()).thenReturn(Collections.singletonMap("istio", "true"));
+        assertThat(predicate.test(booster)).isTrue();
+    }
+
+}

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -90,6 +90,12 @@ objects:
               configMapKeyRef:
                 name: launcher
                 key: launcher.backend.catalog.git.ref
+          - name: LAUNCHER_BOOSTER_CATALOG_FILTER
+            valueFrom:
+              configMapKeyRef:
+                name: launcher
+                key: launcher.backend.catalog.filter
+                optional: true
           - name: LAUNCHER_BACKEND_CATALOG_REINDEX_TOKEN
             valueFrom:
               configMapKeyRef:


### PR DESCRIPTION
This introduces a Predicate<RhoarBooster> implementation that can be activated by providing the `LAUNCHER_BOOSTER_CATALOG_FILTER` env param/system property.

The script must evaluate to a boolean using the `booster` variable, that is an instance of RhoarBooster.

Examples:

- `booster.mission.id == 'rest-http'`: will return only HTTP Rest mission boosters
- `booster.runtime.id == 'spring-boot'`: returns only the Spring Boot boosters
- `booster.mission.id == 'rest-http' && booster.runtime.id` == 'spring-boot': returns only HTTP Rest Spring Boot boosters
- `booster.metadata.istio`: returns only boosters that contains the `istio: true` flag in the booster metadata
- `booster.mission.metadata.istio`: returns only boosters that contains the `istio: true` flag in the mission metadata assigned to the booster

Fixes: https://github.com/fabric8-launcher/launcher-planning/issues/153