### PR TITLE
fix(keycloak): handle errors in KeycloakIdentityProvider

### DIFF
--- a/core/core-impl/src/main/java/io/fabric8/launcher/core/impl/identity/KeycloakIdentityProvider.java
+++ b/core/core-impl/src/main/java/io/fabric8/launcher/core/impl/identity/KeycloakIdentityProvider.java
@@ -85,7 +85,12 @@ public class KeycloakIdentityProvider implements IdentityProvider {
         Request request = securedRequest(authorization)
                 .url(url)
                 .build();
-        return httpClient.executeAndMap(request, KeycloakIdentityProvider::parseIdentity);
+        try {
+            return httpClient.executeAndMap(request, KeycloakIdentityProvider::parseIdentity);
+        } catch (final Exception e) {
+            logger.log(Level.FINE, "Error while fetching token from keycloak for provider: " + service, e);
+            return Optional.empty();
+        }
     }
 
     static String buildURL(String host, String realm, String provider) {

--- a/core/core-impl/src/test/resources/hoverfly/keycloakidentityproviderhoverflytest/should_get_cluster_token_correctly.json
+++ b/core/core-impl/src/test/resources/hoverfly/keycloakidentityproviderhoverflytest/should_get_cluster_token_correctly.json
@@ -26,16 +26,17 @@
       },
       "response" : {
         "status" : 200,
-        "body" : "{\"access_token\":\"zjenfgzgneuiznrgnizrnguini38338\",\"expires_in\":31536000,\"scope\":\"user:full\",\"token_type\":\"Bearer\"}\n",
+        "body" : "{\"access_token\":\"3Y7337fbefbhebfezzfe\",\"expires_in\":31536000,\"scope\":\"user:full\",\"token_type\":\"Bearer\"}\n",
         "encodedBody" : false,
         "templated" : false,
         "headers" : {
           "Cache-Control" : [ "no-cache" ],
+          "Content-Length" : [ "127" ],
           "Content-Type" : [ "application/octet-stream" ],
-          "Date" : [ "Mon, 16 Apr 2018 13:41:40 GMT" ],
+          "Date" : [ "Tue, 24 Apr 2018 08:50:51 GMT" ],
           "Hoverfly" : [ "Was-Here" ],
           "Server" : [ "WildFly/10" ],
-          "Set-Cookie" : [ "2a530402eed8ed6bf7994796747fe947=5e6880a22d34754c7dac231340f324af; path=/; HttpOnly; Secure" ],
+          "Set-Cookie" : [ "2a530402eed8ed6bf7994796747fe947=08661924a4020c406fcedd2424198298; path=/; HttpOnly; Secure" ],
           "Transfer-Encoding" : [ "chunked" ],
           "X-Powered-By" : [ "Undertow/1" ]
         }

--- a/core/core-impl/src/test/resources/hoverfly/keycloakidentityproviderhoverflytest/should_get_empty_when_cluster_is_not_connected.json
+++ b/core/core-impl/src/test/resources/hoverfly/keycloakidentityproviderhoverflytest/should_get_empty_when_cluster_is_not_connected.json
@@ -1,0 +1,51 @@
+{
+  "data" : {
+    "pairs" : [ {
+      "request" : {
+        "path" : {
+          "exactMatch" : "/auth/realms/rh-developers-launch/broker/starter-us-west-2/token"
+        },
+        "method" : {
+          "exactMatch" : "GET"
+        },
+        "destination" : {
+          "exactMatch" : "sso.openshift.io"
+        },
+        "scheme" : {
+          "exactMatch" : "https"
+        },
+        "query" : {
+          "exactMatch" : ""
+        },
+        "body" : {
+          "exactMatch" : ""
+        },
+        "headers" : {
+          "Authorization" : [ "Bearer efbheifb279272FUHUEHFHUEHF" ]
+        }
+      },
+      "response" : {
+        "status" : 400,
+        "body" : "{\"errorMessage\":\"User [fde82f75-dca9-477b-a71d-394386d830be] is not associated with identity provider [starter-us-west-2].\"}",
+        "encodedBody" : false,
+        "templated" : false,
+        "headers" : {
+          "Content-Length" : [ "124" ],
+          "Content-Type" : [ "application/json" ],
+          "Date" : [ "Tue, 24 Apr 2018 08:50:53 GMT" ],
+          "Hoverfly" : [ "Was-Here" ],
+          "Server" : [ "WildFly/10" ],
+          "Set-Cookie" : [ "2a530402eed8ed6bf7994796747fe947=5e6880a22d34754c7dac231340f324af; path=/; HttpOnly; Secure" ],
+          "Transfer-Encoding" : [ "chunked" ],
+          "X-Powered-By" : [ "Undertow/1" ]
+        }
+      }
+    } ],
+    "globalActions" : {
+      "delays" : [ ]
+    }
+  },
+  "meta" : {
+    "schemaVersion" : "v4"
+  }
+}

--- a/core/core-impl/src/test/resources/hoverfly/keycloakidentityproviderhoverflytest/should_get_empty_with_invalid_token.json
+++ b/core/core-impl/src/test/resources/hoverfly/keycloakidentityproviderhoverflytest/should_get_empty_with_invalid_token.json
@@ -1,0 +1,51 @@
+{
+  "data" : {
+    "pairs" : [ {
+      "request" : {
+        "path" : {
+          "exactMatch" : "/auth/realms/rh-developers-launch/broker/github/token"
+        },
+        "method" : {
+          "exactMatch" : "GET"
+        },
+        "destination" : {
+          "exactMatch" : "sso.openshift.io"
+        },
+        "scheme" : {
+          "exactMatch" : "https"
+        },
+        "query" : {
+          "exactMatch" : ""
+        },
+        "body" : {
+          "exactMatch" : ""
+        },
+        "headers" : {
+          "Authorization" : [ "Bearer invalid_token" ]
+        }
+      },
+      "response" : {
+        "status" : 400,
+        "body" : "{\"errorMessage\":\"Invalid token.\"}",
+        "encodedBody" : false,
+        "templated" : false,
+        "headers" : {
+          "Content-Length" : [ "33" ],
+          "Content-Type" : [ "application/json" ],
+          "Date" : [ "Tue, 24 Apr 2018 08:50:52 GMT" ],
+          "Hoverfly" : [ "Was-Here" ],
+          "Server" : [ "WildFly/10" ],
+          "Set-Cookie" : [ "2a530402eed8ed6bf7994796747fe947=a36acf478dd34d4b3c067c496b1ac6cf; path=/; HttpOnly; Secure" ],
+          "Transfer-Encoding" : [ "chunked" ],
+          "X-Powered-By" : [ "Undertow/1" ]
+        }
+      }
+    } ],
+    "globalActions" : {
+      "delays" : [ ]
+    }
+  },
+  "meta" : {
+    "schemaVersion" : "v4"
+  }
+}

--- a/core/core-impl/src/test/resources/hoverfly/keycloakidentityproviderhoverflytest/should_get_github_token_correctly.json
+++ b/core/core-impl/src/test/resources/hoverfly/keycloakidentityproviderhoverflytest/should_get_github_token_correctly.json
@@ -26,16 +26,17 @@
       },
       "response" : {
         "status" : 200,
-        "body" : "access_token=39737RrIEUFHUeuhufieufh&scope=admin%3Arepo_hook%2Crepo&token_type=bearer",
+        "body" : "access_token=3Y7337fbefbhebfezzfe&scope=admin%3Arepo_hook%2Crepo&token_type=bearer",
         "encodedBody" : false,
         "templated" : false,
         "headers" : {
           "Cache-Control" : [ "no-cache" ],
+          "Content-Length" : [ "102" ],
           "Content-Type" : [ "application/octet-stream" ],
-          "Date" : [ "Mon, 16 Apr 2018 13:41:41 GMT" ],
+          "Date" : [ "Tue, 24 Apr 2018 08:50:53 GMT" ],
           "Hoverfly" : [ "Was-Here" ],
           "Server" : [ "WildFly/10" ],
-          "Set-Cookie" : [ "2a530402eed8ed6bf7994796747fe947=08661924a4020c406fcedd2424198298; path=/; HttpOnly; Secure" ],
+          "Set-Cookie" : [ "2a530402eed8ed6bf7994796747fe947=5e6880a22d34754c7dac231340f324af; path=/; HttpOnly; Secure" ],
           "Transfer-Encoding" : [ "chunked" ],
           "X-Powered-By" : [ "Undertow/1" ]
         }


### PR DESCRIPTION
Following previous behavior getIdentity/getIdentityAsync are supposed to catch and log exception then return empty. This was causing the error because the endpoint was failing on the first unconnected cluster.

Closes #351