### PR TITLE
fix(osio): bug fix for build pipeline

### DIFF
--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/steps/OpenShiftSteps.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/steps/OpenShiftSteps.java
@@ -66,8 +66,9 @@ public class OpenShiftSteps {
         String namespace = tenant.getDefaultUserNamespace().getName();
         String gitOwnerName = gitService.getLoggedUser().getLogin();
         String gitOrganizationName = projectile.getGitOrganization();
+        String gitRepositoryOwner = gitOwnerName;
         if (gitOrganizationName != null) {
-            gitOwnerName = gitOrganizationName;
+            gitRepositoryOwner = gitOrganizationName;
         }
         String gitRepoName = repository.getFullName().substring(repository.getFullName().indexOf('/') + 1);
         ConfigMap cm = openShiftService.getConfigMap(gitOwnerName, namespace).orElse(null);
@@ -87,7 +88,7 @@ public class OpenShiftSteps {
         String configXml = data.get("config.xml");
         JenkinsConfigParser configParser = new JenkinsConfigParser(configXml);
         configParser.setRepository(gitRepoName);
-        configParser.setGithubOwner(gitOwnerName);
+        configParser.setGithubOwner(gitRepositoryOwner);
         data.put("config.xml", configParser.toXml());
 
         if (update) {


### PR DESCRIPTION
Build pipeline showing two builds
1. `applicationName` 
2. `githubUsername/organizationName.applicationName`
related issue: https://github.com/openshiftio/openshift.io/issues/3281

Closes https://github.com/openshiftio/openshift.io/issues/3281
