### PR TITLE
fix(osio): make OsioIdentityProvider return empty when an error occurs

### DIFF
--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/client/OsioWitClient.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/client/OsioWitClient.java
@@ -24,6 +24,7 @@ import okhttp3.Request;
 import okhttp3.Response;
 
 import static io.fabric8.launcher.base.http.Requests.securedRequest;
+import static io.fabric8.launcher.base.http.Requests.urlEncode;
 import static io.fabric8.launcher.osio.OsioConfigs.getWitUrl;
 import static io.fabric8.utils.URLUtils.pathJoin;
 import static java.util.Objects.requireNonNull;
@@ -81,7 +82,7 @@ public class OsioWitClient {
      * @return the {@link Optional<Space>}
      */
     public Optional<Space> findSpaceById(final String spaceId) {
-        final Request request = newAuthorizedRequestBuilder("/api/spaces/" + spaceId).build();
+        final Request request = newAuthorizedRequestBuilder("/api/spaces/" + urlEncode(spaceId)).build();
         return httpClient.executeAndParseJson(request, OsioWitClient::readSpace);
     }
 
@@ -125,7 +126,7 @@ public class OsioWitClient {
      * @param spaceId the spaceId
      */
     public boolean deleteSpace(final String spaceId) {
-        final Request request = newAuthorizedRequestBuilder("/api/spaces/" + spaceId)
+        final Request request = newAuthorizedRequestBuilder("/api/spaces/" + urlEncode(spaceId))
                 .delete()
                 .build();
         return httpClient.execute(request);

--- a/addons/osio-addon/src/test/resources/hoverfly/osioidentityprovidertest/should_get_cluster_token_correctly.json
+++ b/addons/osio-addon/src/test/resources/hoverfly/osioidentityprovidertest/should_get_cluster_token_correctly.json
@@ -1,0 +1,11 @@
+{
+  "data" : {
+    "pairs" : [ ],
+    "globalActions" : {
+      "delays" : [ ]
+    }
+  },
+  "meta" : {
+    "schemaVersion" : "v4"
+  }
+}

--- a/addons/osio-addon/src/test/resources/hoverfly/osioidentityprovidertest/should_get_empty_with_invalid_token.json
+++ b/addons/osio-addon/src/test/resources/hoverfly/osioidentityprovidertest/should_get_empty_with_invalid_token.json
@@ -21,21 +21,21 @@
           "exactMatch" : ""
         },
         "headers" : {
-          "Authorization" : [ "Bearer *" ]
+          "Authorization" : [ "Bearer invalid_token" ]
         }
       },
       "response" : {
-        "status" : 200,
-        "body" : "H4sIAAAAAAAC/xzOTWrDMBDF8X1PYd7aaVJ/1IkuI0bjqS0Se8RIKpTSuxd7++M9+P+CmCVnX/QpOxy6W9cP3NHE40c/3JnmG9HwFe5jLxN/jo9xCtMjDGiRTL/jLOYpRV/tBYe1lJTd9brEstbwzrqhRWZNAgeat7g7k6R+VX02JjQ7taU5qKlZrFliLmhxxvjyc96CkImhxbHYaTtMc9QLx8uL6s6rGP7e/gMAAP//bSTDxMoAAAA=",
+        "status" : 401,
+        "body" : "H4sIAAAAAAAC/zTMMQoCMRAF0N5TLL9OobBVOguPoI3IMjojfjYkksxauOTuomD/eCus1lIb4nnFraghwstseXpJooqz5OkuTKYIUHNh+pOBbWD+OQRQEfE8Hew6znsENBdfGiLG7Q4BTk/f/Jhl8UepfJuiX/rmEwAA///3sLNJggAAAA==",
         "encodedBody" : true,
         "templated" : false,
         "headers" : {
-          "Cache-Control" : [ "private" ],
           "Content-Encoding" : [ "gzip" ],
-          "Content-Type" : [ "application/vnd.externaltoken+json" ],
-          "Date" : [ "Fri, 30 Mar 2018 14:53:10 GMT" ],
+          "Content-Length" : [ "133" ],
+          "Content-Type" : [ "application/vnd.api+json" ],
+          "Date" : [ "Tue, 24 Apr 2018 14:04:55 GMT" ],
           "Hoverfly" : [ "Was-Here" ],
-          "Set-Cookie" : [ "e34e98867209bf46ef5ba89f156de53f=a0b2367f7fad313219c495a9101344c0; path=/; HttpOnly; Secure" ],
+          "Set-Cookie" : [ "e34e98867209bf46ef5ba89f156de53f=5c08b8624450b5a539e5f6eceed56838; path=/; HttpOnly; Secure" ],
           "Transfer-Encoding" : [ "chunked" ],
           "Vary" : [ "Accept-Encoding" ]
         }

--- a/addons/osio-addon/src/test/resources/hoverfly/osioidentityprovidertest/should_get_github_token_correctly.json
+++ b/addons/osio-addon/src/test/resources/hoverfly/osioidentityprovidertest/should_get_github_token_correctly.json
@@ -1,0 +1,52 @@
+{
+  "data" : {
+    "pairs" : [ {
+      "request" : {
+        "path" : {
+          "exactMatch" : "/api/token"
+        },
+        "method" : {
+          "exactMatch" : "GET"
+        },
+        "destination" : {
+          "globMatch" : "auth.*.io"
+        },
+        "scheme" : {
+          "exactMatch" : "https"
+        },
+        "query" : {
+          "exactMatch" : "for=https://github.com"
+        },
+        "body" : {
+          "exactMatch" : ""
+        },
+        "headers" : {
+          "Authorization" : [ "Bearer jneoufze937973HFRH" ]
+        }
+      },
+      "response" : {
+        "status" : 200,
+        "body" : "H4sIAAAAAAAC/yTO0YrDIBCF4ft9ijLXYZs2iVFfRkYdGmnjyKgLZdl3X5Lefj8Hzi9gCFSra/ykDBZmms26TKju+nbzy7iou9JhNutqRjWNq1o0aW9GGKAI/6RI4rAk1+UFFrbWSrXX6yO1rfvvwDsMUAMXAgsY95StUGG3MT8vQhgty+NSun+l4I7ywV5JYIDzk2vvc+0J5dQjZtwPSzhhjm/4+/oPAAD///+aOVrIAAAA",
+        "encodedBody" : true,
+        "templated" : false,
+        "headers" : {
+          "Cache-Control" : [ "private" ],
+          "Content-Encoding" : [ "gzip" ],
+          "Content-Length" : [ "180" ],
+          "Content-Type" : [ "application/vnd.externaltoken+json" ],
+          "Date" : [ "Tue, 24 Apr 2018 14:04:56 GMT" ],
+          "Hoverfly" : [ "Was-Here" ],
+          "Set-Cookie" : [ "e34e98867209bf46ef5ba89f156de53f=5c08b8624450b5a539e5f6eceed56838; path=/; HttpOnly; Secure" ],
+          "Transfer-Encoding" : [ "chunked" ],
+          "Vary" : [ "Accept-Encoding" ]
+        }
+      }
+    } ],
+    "globalActions" : {
+      "delays" : [ ]
+    }
+  },
+  "meta" : {
+    "schemaVersion" : "v4"
+  }
+}

--- a/base/src/main/java/io/fabric8/launcher/base/http/Requests.java
+++ b/base/src/main/java/io/fabric8/launcher/base/http/Requests.java
@@ -1,5 +1,8 @@
 package io.fabric8.launcher.base.http;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
 import io.fabric8.launcher.base.identity.Identity;
 import okhttp3.Request;
 
@@ -31,5 +34,19 @@ public final class Requests {
      */
     public static Request.Builder securedRequest(final Identity identity) {
         return new Request.Builder().header(identity.getDefaultAuthorizationType().getHeaderName(), identity.toRequestAuthorization());
+    }
+
+    /**
+     * Encode a param in order to add it to an URL
+     *
+     * @param param the param to encode
+     * @return the encoded param
+     */
+    public static String urlEncode(final String param) {
+        try {
+            return URLEncoder.encode(param, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalStateException(e);
+        }
     }
 }

--- a/core/core-api/src/main/java/io/fabric8/launcher/core/spi/IdentityProvider.java
+++ b/core/core-api/src/main/java/io/fabric8/launcher/core/spi/IdentityProvider.java
@@ -2,7 +2,6 @@ package io.fabric8.launcher.core.spi;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 import io.fabric8.launcher.base.identity.Identity;
 import io.fabric8.launcher.base.identity.TokenIdentity;
@@ -32,16 +31,7 @@ public interface IdentityProvider {
      * @param service       the service where this identity belongs to. See {@link ServiceType}
      * @return a {@link CompletableFuture} returning an {@link Optional<Identity>}
      */
-    default Optional<Identity> getIdentity(TokenIdentity authorization, String service) {
-        try {
-            return getIdentityAsync(authorization, service).get();
-        } catch (final InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new IllegalStateException("Interrupted while getting identity for service " + service, e);
-        } catch (final ExecutionException e) {
-            throw new IllegalStateException("Error while getting identity for service " + service, e);
-        }
-    }
+    Optional<Identity> getIdentity(TokenIdentity authorization, String service);
 
     interface ServiceType {
         String GITHUB = "github";

--- a/core/core-impl/src/test/java/io/fabric8/launcher/core/impl/identity/KeycloakIdentityProviderHoverflyTest.java
+++ b/core/core-impl/src/test/java/io/fabric8/launcher/core/impl/identity/KeycloakIdentityProviderHoverflyTest.java
@@ -40,7 +40,7 @@ public class KeycloakIdentityProviderHoverflyTest {
     public JUnitSoftAssertions softly = new JUnitSoftAssertions();
 
     @Test
-    public void should_get_gitHub_token_correctly() throws Exception {
+    public void should_get_github_token_correctly() throws Exception {
         final IdentityProvider keycloakIdentityProvider = new KeycloakIdentityProvider(HttpClient.create());
 
         final Optional<Identity> gitHubIdentityAsync = keycloakIdentityProvider.getIdentityAsync(getKeycloakToken(), "github").get();

--- a/services/git-service-impl/src/main/java/io/fabric8/launcher/service/git/Gits.java
+++ b/services/git-service-impl/src/main/java/io/fabric8/launcher/service/git/Gits.java
@@ -1,7 +1,5 @@
 package io.fabric8.launcher.service.git;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
@@ -20,20 +18,6 @@ public final class Gits {
 
     private Gits() {
         throw new IllegalAccessError();
-    }
-
-    /**
-     * Encode a param in order to add it to an URL
-     *
-     * @param param the param to encode
-     * @return the encoded param
-     */
-    public static String encode(final String param) {
-        try {
-            return URLEncoder.encode(param, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new IllegalStateException(e);
-        }
     }
 
     /**

--- a/services/git-service-impl/src/main/java/io/fabric8/launcher/service/git/bitbucket/BitbucketService.java
+++ b/services/git-service-impl/src/main/java/io/fabric8/launcher/service/git/bitbucket/BitbucketService.java
@@ -34,10 +34,10 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 
 import static io.fabric8.launcher.base.http.Requests.securedRequest;
+import static io.fabric8.launcher.base.http.Requests.urlEncode;
 import static io.fabric8.launcher.service.git.Gits.checkGitRepositoryFullNameArgument;
 import static io.fabric8.launcher.service.git.Gits.checkGitRepositoryNameArgument;
 import static io.fabric8.launcher.service.git.Gits.createGitRepositoryFullName;
-import static io.fabric8.launcher.service.git.Gits.encode;
 import static io.fabric8.launcher.service.git.Gits.isValidGitRepositoryFullName;
 import static io.fabric8.launcher.service.git.bitbucket.api.BitbucketWebhookEvent.ISSUE_COMMENT_CREATED;
 import static io.fabric8.launcher.service.git.bitbucket.api.BitbucketWebhookEvent.PULL_REQUEST_CREATED;
@@ -94,10 +94,10 @@ public class BitbucketService extends AbstractGitService implements GitService {
         } else {
             owner = getLoggedUser().getLogin();
         }
-        final StringBuilder urlBuilder = new StringBuilder(String.format("%s/2.0/repositories/%s?pagelen=100", BITBUCKET_URL, encode(owner)));
+        final StringBuilder urlBuilder = new StringBuilder(String.format("%s/2.0/repositories/%s?pagelen=100", BITBUCKET_URL, urlEncode(owner)));
         if (isNotEmpty(filter.withNameContaining())) {
             final String query = "name~\"" + filter.withNameContaining() + "\"";
-            urlBuilder.append("&q=").append(encode(query));
+            urlBuilder.append("&q=").append(urlEncode(query));
         }
         final Request request = request()
                 .get()
@@ -250,7 +250,7 @@ public class BitbucketService extends AbstractGitService implements GitService {
         requireNonNull(webhook, "webhook must not be null.");
         checkGitRepositoryFullNameArgument(repository.getFullName());
 
-        final String url = String.format("%s/2.0/repositories/%s/hooks/%s", BITBUCKET_URL, repository.getFullName(), encode(webhook.getName()));
+        final String url = String.format("%s/2.0/repositories/%s/hooks/%s", BITBUCKET_URL, repository.getFullName(), urlEncode(webhook.getName()));
         final Request request = request()
                 .delete()
                 .url(url)
@@ -270,7 +270,7 @@ public class BitbucketService extends AbstractGitService implements GitService {
     private GitOrganization checkOrganizationExists(final String name) {
         requireNonNull(name, "name must be specified.");
 
-        final String url = String.format("%s/2.0/teams/%s", BITBUCKET_URL, encode(name));
+        final String url = String.format("%s/2.0/teams/%s", BITBUCKET_URL, urlEncode(name));
         final Request request = request()
                 .get()
                 .url(url)

--- a/services/git-service-impl/src/main/java/io/fabric8/launcher/service/git/gitlab/GitLabService.java
+++ b/services/git-service-impl/src/main/java/io/fabric8/launcher/service/git/gitlab/GitLabService.java
@@ -37,10 +37,10 @@ import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 
 import static io.fabric8.launcher.base.http.AuthorizationType.PRIVATE_TOKEN;
 import static io.fabric8.launcher.base.http.Requests.securedRequest;
+import static io.fabric8.launcher.base.http.Requests.urlEncode;
 import static io.fabric8.launcher.service.git.Gits.checkGitRepositoryFullNameArgument;
 import static io.fabric8.launcher.service.git.Gits.checkGitRepositoryNameArgument;
 import static io.fabric8.launcher.service.git.Gits.createGitRepositoryFullName;
-import static io.fabric8.launcher.service.git.Gits.encode;
 import static io.fabric8.launcher.service.git.Gits.isValidGitRepositoryFullName;
 import static io.fabric8.launcher.service.git.gitlab.api.GitLabWebhookEvent.ISSUES;
 import static io.fabric8.launcher.service.git.gitlab.api.GitLabWebhookEvent.MERGE_REQUESTS;
@@ -108,7 +108,7 @@ class GitLabService extends AbstractGitService implements GitService {
         }
         urlBuilder.append("/projects");
         if (isNotEmpty(filter.withNameContaining())) {
-            urlBuilder.append("?search=").append(encode(filter.withNameContaining()));
+            urlBuilder.append("?search=").append(urlEncode(filter.withNameContaining()));
         }
         Request request = request()
                 .get()
@@ -185,7 +185,7 @@ class GitLabService extends AbstractGitService implements GitService {
 
         Request request = request()
                 .get()
-                .url(GITLAB_URL + "/api/v4/projects/" + encode(repositoryFullName))
+                .url(GITLAB_URL + "/api/v4/projects/" + urlEncode(repositoryFullName))
                 .build();
         return httpClient.executeAndParseJson(request, GitLabService::readGitRepository);
     }
@@ -196,7 +196,7 @@ class GitLabService extends AbstractGitService implements GitService {
 
         Request request = request()
                 .delete()
-                .url(GITLAB_URL + "/api/v4/projects/" + encode(repositoryFullName))
+                .url(GITLAB_URL + "/api/v4/projects/" + urlEncode(repositoryFullName))
                 .build();
         httpClient.execute(request);
     }
@@ -212,7 +212,7 @@ class GitLabService extends AbstractGitService implements GitService {
         content.append("url=").append(webhookUrl);
         if (secret != null && secret.length() > 0) {
             content.append("&token=")
-                    .append(encode(secret));
+                    .append(urlEncode(secret));
         }
         for (String event : effectiveEvents) {
             content.append("&")
@@ -221,7 +221,7 @@ class GitLabService extends AbstractGitService implements GitService {
         }
         Request request = request()
                 .post(RequestBody.create(APPLICATION_FORM_URLENCODED, content.toString()))
-                .url(GITLAB_URL + "/api/v4/projects/" + encode(repository.getFullName()) + "/hooks")
+                .url(GITLAB_URL + "/api/v4/projects/" + urlEncode(repository.getFullName()) + "/hooks")
                 .build();
 
         return httpClient.executeAndParseJson(request, this::readHook).orElse(null);
@@ -234,7 +234,7 @@ class GitLabService extends AbstractGitService implements GitService {
 
         Request request = request()
                 .get()
-                .url(GITLAB_URL + "/api/v4/projects/" + encode(repository.getFullName()) + "/hooks")
+                .url(GITLAB_URL + "/api/v4/projects/" + urlEncode(repository.getFullName()) + "/hooks")
                 .build();
         return httpClient.executeAndParseJson(request, (JsonNode tree) ->
                 StreamSupport.stream(tree.spliterator(), false)
@@ -262,7 +262,7 @@ class GitLabService extends AbstractGitService implements GitService {
 
         Request request = request()
                 .delete()
-                .url(GITLAB_URL + "/api/v4/projects/" + encode(repository.getFullName()) + "/hooks/" + webhook.getName())
+                .url(GITLAB_URL + "/api/v4/projects/" + urlEncode(repository.getFullName()) + "/hooks/" + webhook.getName())
                 .build();
         httpClient.execute(request);
     }
@@ -282,7 +282,7 @@ class GitLabService extends AbstractGitService implements GitService {
     private String checkOrganizationExistsAndReturnId(final String name) {
         requireNonNull(name, "name must be specified.");
 
-        final String url = GITLAB_URL + "/api/v4/groups/" + encode(name);
+        final String url = GITLAB_URL + "/api/v4/groups/" + urlEncode(name);
         final Request request = request()
                 .get()
                 .url(url)


### PR DESCRIPTION
- Make OsioIdentityProvider like KeycloakIdentityProvider by always returning empty in case of error. We should change this when solving #354.
- Make OsioIdentityProvider more strict by only accepting "github" or "openshift-v3" as provider.
- Add urlEncode to Requests and use it in Osio clients.