### PR TITLE
fix: removed duplicate null check in TokenIdentity.fromBearerAuthorizationHeader

### DIFF
--- a/base/src/main/java/io/fabric8/launcher/base/identity/TokenIdentity.java
+++ b/base/src/main/java/io/fabric8/launcher/base/identity/TokenIdentity.java
@@ -24,7 +24,6 @@ public interface TokenIdentity extends Identity {
     }
 
     static TokenIdentity fromBearerAuthorizationHeader(String authorizationHeader) {
-        requireNonNull(authorizationHeader, "authorizationHeader must be specified.");
         if (!isBearerAuthentication(authorizationHeader)) {
             throw new IllegalArgumentException("Invalid bearer authentication header: " + authorizationHeader);
         }


### PR DESCRIPTION
Authorizations.isBearerAuthentication already checks for null values and the test throws a better exception message.

This is	an attempt to figure out what is causing issue #351