### PR TITLE
fix: remove online

### DIFF
--- a/core/core-api/src/main/java/io/fabric8/launcher/core/api/events/StatusEventType.java
+++ b/core/core-api/src/main/java/io/fabric8/launcher/core/api/events/StatusEventType.java
@@ -8,7 +8,7 @@ public enum StatusEventType {
 
     GITHUB_CREATE("Creating your new GitHub repository"),
     GITHUB_PUSHED("Pushing your customized Booster code into the repo"),
-    OPENSHIFT_CREATE("Creating your project on OpenShift Online"),
+    OPENSHIFT_CREATE("Creating your project on OpenShift"),
     OPENSHIFT_PIPELINE("Setting up your build pipeline"),
     GITHUB_WEBHOOK("Configuring to trigger builds on Git pushes");
 


### PR DESCRIPTION
### Why

Not all builds go to Openshift Online

### Description

Removed the word "Online"

### Checklist

- [x] I followed the contribution [guidelines](https://raw.githubusercontent.com/fabric8-launcher/launcher-backend/master/CONTRIBUTING.md).
- [ ] I created an [issue](https://github.com/fabric8-launcher/launcher-backend/issues/new) and used it in the commit message.
- [x] I have built the project locally prior to submission with `mvn clean install`.
- [x] I kept a clean commit log (no unnecessary commits, no merge commits).
- [ ] I am happy with my contribution.
