### PR TITLE
Deploy on RHEL based container

### DIFF
--- a/Dockerfile.deploy.rhel
+++ b/Dockerfile.deploy.rhel
@@ -1,0 +1,40 @@
+FROM prod.registry.devshift.net/osio-prod/base/jboss-jdk-8:latest
+LABEL maintainer "Devtools <devtools@redhat.com>"
+LABEL author "Devtools <devtools@redhat.com>"
+
+EXPOSE 8080
+EXPOSE 8443
+
+ENV LANG=en_US.UTF-8
+
+USER root
+
+RUN chgrp -R 0 /opt/jboss &&\
+    chmod -R g+rw /opt/jboss &&\
+    find /opt/jboss -type d -exec chmod g+x {} + &&\
+    git config --system user.name openshiftio-launchpad &&\
+    git config --system user.email obsidian-leadership@redhat.com
+
+USER jboss
+
+COPY target/launcher-backend-swarm.jar ./
+
+CMD ["sh", "-c", "java -Djava.net.preferIPv4Stack=true \
+                        -XX:+UnlockExperimentalVMOptions \
+                        -XX:+UseCGroupMemoryLimitForHeap \
+                        -XX:MaxRAMFraction=1 \
+                        -XX:MetaspaceSize=96M \
+                        -XX:MaxMetaspaceSize=512m \
+                        -XX:AdaptiveSizePolicyWeight=90 \
+                        -XX:+ExitOnOutOfMemoryError \
+                        -XX:+HeapDumpOnOutOfMemoryError \
+                        -XX:+UseParallelGC \
+                        -XX:MinHeapFreeRatio=20 \
+                        -XX:MaxHeapFreeRatio=40 \
+                        -XX:CICompilerCount=2 \
+                        -XX:ParallelGCThreads=1 \
+                        -XX:ConcGCThreads=1 \
+                        -XX:GCTimeRatio=4 \
+                        -XshowSettings:vm \
+                        $JAVA_OPTS \
+                        -jar launcher-backend-swarm.jar"]

--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -5,76 +5,84 @@ REGISTRY_URI="push.registry.devshift.net"
 REGISTRY_NS="fabric8"
 REGISTRY_IMAGE="launcher-backend"
 DOCKER_HUB_URL=${REGISTRY_NS}/${REGISTRY_IMAGE}
-REGISTRY_URL=${REGISTRY_URI}/${DOCKER_HUB_URL}
 BUILDER_IMAGE="launcher-backend-builder"
 BUILDER_CONT="launcher-backend-builder-container"
 DEPLOY_IMAGE="launcher-backend-deploy"
 
+if [ "$TARGET" = "rhel" ]; then
+    REGISTRY_URL=${REGISTRY_URI}/osio-prod/${DOCKER_HUB_URL}
+    DOCKERFILE_DEPLOY="Dockerfile.deploy.rhel"
+else
+    REGISTRY_URL=${REGISTRY_URI}/${DOCKER_HUB_URL}
+    DOCKERFILE_DEPLOY="Dockerfile.deploy"
+fi
+
 TARGET_DIR="target"
 
-function tag_push() {
-    TARGET_IMAGE=$1
-    USERNAME=$2
-    PASSWORD=$3
-    REGISTRY=$4
+docker_login() {
+    local USERNAME=$1
+    local PASSWORD=$2
+    local REGISTRY=$3
 
-    docker tag ${DEPLOY_IMAGE} ${TARGET_IMAGE}
     if [ -n "${USERNAME}" ] && [ -n "${PASSWORD}" ]; then
         docker login -u ${USERNAME} -p ${PASSWORD} ${REGISTRY}
     fi
-    docker push ${TARGET_IMAGE}
+}
 
+tag_push() {
+    local TARGET_IMAGE=$1
+
+    docker tag ${DEPLOY_IMAGE} ${TARGET_IMAGE}
+    docker push ${TARGET_IMAGE}
 }
 
 # Exit on error
 set -e
 
-if [ -z $CICO_LOCAL ]; then
+if [ -z "$CICO_LOCAL" ]; then
     [ -f jenkins-env ] && cat jenkins-env | grep -e PASS -e GIT -e DEVSHIFT -e SONAR > inherit-env
     [ -f inherit-env ] && . inherit-env
 
     # We need to disable selinux for now, XXX
-    /usr/sbin/setenforce 0
-
-    # Get all the deps in
-    yum -y install docker make git
+    /usr/sbin/setenforce 0 || :
 
     # Get all the deps in
     yum -y install docker make git
     service docker start
 fi
 
-#CLEAN
-docker ps | grep -q ${BUILDER_CONT} && docker stop ${BUILDER_CONT}
-docker ps -a | grep -q ${BUILDER_CONT} && docker rm ${BUILDER_CONT}
-rm -rf ${TARGET_DIR}/
-
 #BUILD
-docker build -t ${BUILDER_IMAGE} -f Dockerfile.build .
+if [ ! -d "${TARGET_DIR}" ]; then
+    mkdir ${TARGET_DIR}
 
-mkdir ${TARGET_DIR}/
-docker run --detach=true --name ${BUILDER_CONT} -t -v $(pwd)/${TARGET_DIR}:/${TARGET_DIR}:Z ${BUILDER_IMAGE} /bin/tail -f /dev/null #FIXME
+    docker build -t ${BUILDER_IMAGE} -f Dockerfile.build .
 
-docker exec ${BUILDER_CONT} mvn -B clean install -DskipTests -Ddownload.plugin.skip.cache
-docker exec -u root ${BUILDER_CONT} cp web/target/launcher-backend-swarm.jar /${TARGET_DIR}
+    docker run --detach=true --name ${BUILDER_CONT} -t -v $(pwd)/${TARGET_DIR}:/${TARGET_DIR}:Z ${BUILDER_IMAGE} /bin/tail -f /dev/null #FIXME
 
-#BUILD DEPLOY IMAGE
-docker build -t ${DEPLOY_IMAGE} -f Dockerfile.deploy .
+    docker exec ${BUILDER_CONT} mvn -B clean install -DskipTests -Ddownload.plugin.skip.cache
+    docker exec -u root ${BUILDER_CONT} cp web/target/launcher-backend-swarm.jar /${TARGET_DIR}
+fi
 
 #PUSH
-if [ -z $CICO_LOCAL ]; then
+if [ -z "$CICO_LOCAL" ]; then
+    docker_login ${DEVSHIFT_USERNAME} ${DEVSHIFT_PASSWORD} ${REGISTRY_URI}
+
+    docker build -t ${DEPLOY_IMAGE} -f "${DOCKERFILE_DEPLOY}" .
+
     TAG=$(echo $GIT_COMMIT | cut -c1-${DEVSHIFT_TAG_LEN})
 
-    tag_push "${REGISTRY_URL}:${TAG}" ${DEVSHIFT_USERNAME} ${DEVSHIFT_PASSWORD} ${REGISTRY_URI}
-    tag_push "${REGISTRY_URL}:latest" ${DEVSHIFT_USERNAME} ${DEVSHIFT_PASSWORD} ${REGISTRY_URI}
+    tag_push "${REGISTRY_URL}:${TAG}"
+    tag_push "${REGISTRY_URL}:latest"
 
-    if [ -n "${GENERATOR_DOCKER_HUB_PASSWORD}" ]; then
-        tag_push "${DOCKER_HUB_URL}:${TAG}" ${GENERATOR_DOCKER_HUB_USERNAME} ${GENERATOR_DOCKER_HUB_PASSWORD}
-        tag_push "${DOCKER_HUB_URL}:latest" ${GENERATOR_DOCKER_HUB_USERNAME} ${GENERATOR_DOCKER_HUB_PASSWORD}
+    if [[ "$TARGET" != "rhel" && -n "${GENERATOR_DOCKER_HUB_PASSWORD}" ]]; then
+        docker_login ${GENERATOR_DOCKER_HUB_USERNAME} ${GENERATOR_DOCKER_HUB_PASSWORD}
+
+        tag_push "${DOCKER_HUB_URL}:${TAG}"
+        tag_push "${DOCKER_HUB_URL}:latest"
     fi
 fi
 
 #SONAR
 if [ -n "${SONAR_LOGIN}" ]; then
-  docker exec ${BUILDER_CONT} mvn sonar:sonar -Dsonar.organization=fabric8-launcher -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=${SONAR_LOGIN}
+    docker exec ${BUILDER_CONT} mvn sonar:sonar -Dsonar.organization=fabric8-launcher -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=${SONAR_LOGIN}
 fi


### PR DESCRIPTION
Enable build on RHEL if TARGET=rhel.

As part of an effort to migrate the services running in OSIO from CentOS
to RHEL, we are ready to push out the RHEL based image for this service
into staging.

This PR includes a new RHEL based dockerfile for the deployment of the
service.  This dockerfile will be built when this variable is set:
TARGET=rhel.  The build scripts have been adapted to take this into
consideration, and to push the image to different namespaces if the
TARGET is rhel or not.

Currently the deployment builds happen on empty baremetal machines. The
build script will be executed a second time to build and push the
deployment file if TARGET=rhel, so some changes in the build script are
to ensure that it will work if executed a second time.

By merging this PR this service will be deployed to staging. Once we
verify that the RHEL based image works correctly, we can push to prod.