### PR TITLE
feat(booster-catalog): Return booster metadata inside /runtimes

### DIFF
--- a/addons/osio-addon/src/test/java/io/fabric8/launcher/osio/client/OsioWitClientTest.java
+++ b/addons/osio-addon/src/test/java/io/fabric8/launcher/osio/client/OsioWitClientTest.java
@@ -88,7 +88,7 @@ public class OsioWitClientTest {
                 .isNotNull()
                 .hasFieldOrPropertyWithValue("name", "test-wit-client-create")
                 .hasFieldOrProperty("id");
-        softly.assertThat(getOsioWitClient().deleteSpace(space.getId())).isTrue();
+        softly.assertThatCode(() -> getOsioWitClient().deleteSpace(space.getId())).doesNotThrowAnyException();
     }
 
 }

--- a/web/src/main/java/io/fabric8/launcher/web/endpoints/BoosterCatalogEndpoint.java
+++ b/web/src/main/java/io/fabric8/launcher/web/endpoints/BoosterCatalogEndpoint.java
@@ -105,6 +105,13 @@ public class BoosterCatalogEndpoint {
                     if (v.getMetadata() != null && !v.getMetadata().isEmpty()) {
                         version.add("metadata", toJsonObjectBuilder(v.getMetadata()));
                     }
+                    catalog.getBooster(m, r, v).ifPresent(booster -> {
+                        JsonObjectBuilder boosterBuilder = createObjectBuilder();
+                        if (!booster.getMetadata().isEmpty()) {
+                            boosterBuilder.add("metadata", toJsonObjectBuilder(booster.getMetadata()));
+                        }
+                        version.add("booster", boosterBuilder);
+                    });
                     versions.add(version);
                 }
                 mission.add("versions", versions);
@@ -114,7 +121,6 @@ public class BoosterCatalogEndpoint {
             response.add(runtime);
         }
         return Response.ok(response.build()).build();
-
     }
 
     @GET

--- a/web/src/main/webapp/swagger.yaml
+++ b/web/src/main/webapp/swagger.yaml
@@ -895,6 +895,15 @@ components:
         name:
           type: string
           example: 1.5.8.RELEASE (Community)
+        booster:
+          type: object
+          properties:
+            metadata:
+              type: object
+              properties:
+                runsOn:
+                  type: string
+
     Booster:
       type: object
       properties:

--- a/web/src/test/java/io/fabric8/launcher/web/endpoints/osio/OsioEndpointIT.java
+++ b/web/src/test/java/io/fabric8/launcher/web/endpoints/osio/OsioEndpointIT.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.websocket.ContainerProvider;
@@ -226,20 +227,20 @@ public class OsioEndpointIT {
                 getOpenShiftService().deleteBuildConfig(defaultNamespace, p);
                 LOG.info("Deleted build config in namespace " + defaultNamespace + " named " + p);
             } catch (final Exception e) {
-                LOG.severe("Could not delete build config in namespace " + defaultNamespace + " named " + p);
+                LOG.log(Level.SEVERE, "Could not delete build config in namespace " + defaultNamespace + " named " + p, e);
             }
         });
         try {
             getOpenShiftService().deleteConfigMap(defaultNamespace, gitOwner);
             LOG.info("Deleted jenkins config map in namespace " + defaultNamespace + " named " + gitOwner);
         } catch (final Exception e) {
-            LOG.severe("Could not delete jenkins config map in namespace " + defaultNamespace + " named " + gitOwner);
+            LOG.log(Level.SEVERE, "Could not delete jenkins config map in namespace " + defaultNamespace + " named " + gitOwner, e);
         }
         try {
             getWitClient().deleteSpace(space.getId());
             LOG.info("Deleted space " + space.getId() + " named " + space.getName());
         } catch (final Exception e) {
-            LOG.severe("Could not delete space " + space.getId() + " named " + space.getName());
+            LOG.log(Level.SEVERE, "Could not delete space " + space.getId() + " named " + space.getName(), e);
         }
     }
 

--- a/web/src/test/java/io/fabric8/launcher/web/endpoints/osio/OsioEndpointIT.java
+++ b/web/src/test/java/io/fabric8/launcher/web/endpoints/osio/OsioEndpointIT.java
@@ -24,8 +24,8 @@ import io.fabric8.launcher.service.git.Gits;
 import io.fabric8.launcher.service.git.api.GitRepository;
 import io.fabric8.launcher.service.git.github.KohsukeGitHubServiceFactory;
 import io.fabric8.launcher.service.git.spi.GitServiceSpi;
-import io.fabric8.launcher.service.openshift.impl.OpenShiftClusterRegistryImpl;
 import io.fabric8.launcher.service.openshift.impl.Fabric8OpenShiftServiceFactory;
+import io.fabric8.launcher.service.openshift.impl.OpenShiftClusterRegistryImpl;
 import io.fabric8.launcher.service.openshift.spi.OpenShiftServiceSpi;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.response.ResponseBodyExtractionOptions;
@@ -64,15 +64,18 @@ public class OsioEndpointIT {
     private static final String SPACE_NAME = "space-osio-it-" + TEST_ID;
 
     private static final String LAUNCH_PROJECT_NAME = "project-osio-it-launch-" + TEST_ID;
+
     private static final String LAUNCH_MISSION = "rest-http";
+
     private static final String LAUNCH_RUNTIME = "vert.x";
+
     private static final String LAUNCH_RUNTIME_VERSION = "community";
 
     private static final String IMPORT_PROJECT_NAME = "project-osio-it-import-" + TEST_ID;
 
 
-
     private static final List<String> REPOSITORY_TO_CLEAN = ImmutableList.of(LAUNCH_PROJECT_NAME, IMPORT_PROJECT_NAME);
+
     private static final List<String> PROJECT_TO_CLEAN = ImmutableList.of(LAUNCH_PROJECT_NAME, IMPORT_PROJECT_NAME);
 
     @Rule
@@ -186,7 +189,6 @@ public class OsioEndpointIT {
     }
 
 
-
     @Before
     public void waitUntilEndpointIsReady() {
         given()
@@ -217,7 +219,7 @@ public class OsioEndpointIT {
             } catch (final Exception e) {
                 LOG.severe("Could not remove GitHub repo " + fullName + ": " + e.getMessage());
             }
-        }) ;
+        });
         PROJECT_TO_CLEAN.forEach(p -> {
             try {
                 LOG.info("Going to cleanup project: " + p);
@@ -234,14 +236,14 @@ public class OsioEndpointIT {
             LOG.severe("Could not delete jenkins config map in namespace " + defaultNamespace + " named " + gitOwner);
         }
         try {
-            assertThat(getWitClient().deleteSpace(space.getId())).isTrue();
+            getWitClient().deleteSpace(space.getId());
             LOG.info("Deleted space " + space.getId() + " named " + space.getName());
         } catch (final Exception e) {
             LOG.severe("Could not delete space " + space.getId() + " named " + space.getName());
         }
     }
 
-    private static String getDefaultNamespace(){
+    private static String getDefaultNamespace() {
         final Tenant tenant = getWitClient().getTenant();
         return tenant.getDefaultUserNamespace().getName();
     }


### PR DESCRIPTION
The runsOn information inside the booster metadata is necessary to avoid N+1 requests