### PR TITLE
fixes 3784 - Applications starting with a number can't rollout from Jenkins

### DIFF
--- a/web/src/main/java/io/fabric8/launcher/web/endpoints/inputs/LaunchProjectileInput.java
+++ b/web/src/main/java/io/fabric8/launcher/web/endpoints/inputs/LaunchProjectileInput.java
@@ -18,6 +18,10 @@ import static io.fabric8.launcher.service.git.api.GitService.GIT_NAME_REGEXP;
  */
 public class LaunchProjectileInput implements LauncherProjectileContext {
 
+    public static final String PROJECT_NAME_REGEX = "^[a-zA-Z](?!.*--)(?!.*__)[a-zA-Z0-9-_]{2,38}[a-zA-Z0-9]$";
+    public static final String PROJECT_NAME_VALIDATION_MESSAGE = "projectName should consist of only alphanumeric characters, '-' and '_'. " +
+                                                                    "It should start with alphabetic and end with alphanumeric characters.";
+
     @FormParam("gitOrganization")
     @Pattern(message = "gitOrganization should follow consist only of alphanumeric characters, '-', '_' or '.' .",
             regexp = GIT_NAME_REGEXP)
@@ -42,6 +46,8 @@ public class LaunchProjectileInput implements LauncherProjectileContext {
 
     @FormParam("projectName")
     @NotNull(message = "projectName is required")
+    @Pattern(message = PROJECT_NAME_VALIDATION_MESSAGE,
+            regexp = PROJECT_NAME_REGEX)
     private String projectName;
 
     @FormParam("groupId")

--- a/web/src/test/java/io/fabric8/launcher/web/endpoints/inputs/LaunchProjectileInputTest.java
+++ b/web/src/test/java/io/fabric8/launcher/web/endpoints/inputs/LaunchProjectileInputTest.java
@@ -1,0 +1,94 @@
+package io.fabric8.launcher.web.endpoints.inputs;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+import java.io.IOException;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by hrishin on 6/15/18.
+ */
+public class LaunchProjectileInputTest {
+
+    private Validator validator;
+
+    private  JSONObject launchProjectInputs;
+
+    @Before
+    public void init() {
+        initializeValidator();
+        initializeLaunchInputs();
+    }
+
+    @Test
+    public void shouldNotViolateProjectNameConstraints() throws IOException {
+        // GIVEN
+        launchProjectInputs.put("projectName", "Test-_123");
+
+        // WHEN
+        Set<ConstraintViolation<LaunchProjectileInput>> violations = checkConstraintViolations(launchProjectInputs);
+
+        // THEN
+        assertTrue(violations.isEmpty());
+    }
+
+    @Test
+    public void projectNameShouldStartWithAlphabeticCharacters() throws IOException {
+        // GIVEN
+        launchProjectInputs.put("projectName", "123Test");
+
+        // WHEN
+        Set<ConstraintViolation<LaunchProjectileInput>> violations = checkConstraintViolations(launchProjectInputs);
+
+        // THEN
+        assertFalse(violations.isEmpty());
+        assertEquals(hasMessage(violations, LaunchProjectileInput.PROJECT_NAME_VALIDATION_MESSAGE), true);
+    }
+
+    @Test
+    public void projectNameShouldEndWithAlphanumericCharacters() throws IOException {
+        // GIVEN
+        launchProjectInputs.put("projectName", "123Test**");
+
+        // WHEN
+        Set<ConstraintViolation<LaunchProjectileInput>> violations = checkConstraintViolations(launchProjectInputs);
+
+        // THEN
+        assertFalse(violations.isEmpty());
+        assertEquals(hasMessage(violations, LaunchProjectileInput.PROJECT_NAME_VALIDATION_MESSAGE), true);
+    }
+
+    private void initializeLaunchInputs() {
+        launchProjectInputs = new JSONObject();
+        launchProjectInputs.put("runtime", "vertx")
+                .put("mission", "http-vertex")
+                .put("gitRepository", "http-vertex");
+    }
+
+    private void initializeValidator() {
+        ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
+        this.validator = validatorFactory.getValidator();
+    }
+
+    private Set<ConstraintViolation<LaunchProjectileInput>> checkConstraintViolations(JSONObject jsonObject) throws IOException {
+        LaunchProjectileInput projectInput = new ObjectMapper()
+                .readValue(jsonObject.toString(), LaunchProjectileInput.class);
+        return this.validator.validate(projectInput);
+    }
+
+    private boolean hasMessage(Set<ConstraintViolation<LaunchProjectileInput>> violations, String message) {
+        return violations
+                .stream()
+                .anyMatch(v -> v.getMessage().equalsIgnoreCase(message));
+    }
+}


### PR DESCRIPTION
### Why
Jenkins pipeline fails if if project names starts with numers. To prevent such case, added validation check befor launching project.


### Description
- Added validation check on prject name
- Added unit test for project names checksCloses #..


### Checklist

- [X] I followed the contribution [guidelines](https://raw.githubusercontent.com/fabric8-launcher/launcher-backend/master/CONTRIBUTING.md).
- [ ] I created an [issue](https://github.com/fabric8-launcher/launcher-backend/issues/new) and used it in the commit message.
- [X] I have built the project locally prior to submission with `mvn clean install`.
- [X] I kept a clean commit log (no unnecessary commits, no merge commits).
- [X] I am happy with my contribution.

fixes https://github.com/openshiftio/openshift.io/issues/3784