### PR TITLE
fixes project name length issue

### DIFF
--- a/web/src/main/java/io/fabric8/launcher/web/endpoints/inputs/LaunchProjectileInput.java
+++ b/web/src/main/java/io/fabric8/launcher/web/endpoints/inputs/LaunchProjectileInput.java
@@ -2,6 +2,7 @@ package io.fabric8.launcher.web.endpoints.inputs;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.HeaderParam;
@@ -19,8 +20,10 @@ import static io.fabric8.launcher.service.git.api.GitService.GIT_NAME_REGEXP;
 public class LaunchProjectileInput implements LauncherProjectileContext {
 
     public static final String PROJECT_NAME_REGEX = "^[a-zA-Z](?!.*--)(?!.*__)[a-zA-Z0-9-_]{2,38}[a-zA-Z0-9]$";
+    public static final int PROJECT_NAME_MAX_LENGTH = 49;
     public static final String PROJECT_NAME_VALIDATION_MESSAGE = "projectName should consist of only alphanumeric characters, '-' and '_'. " +
-                                                                    "It should start with alphabetic and end with alphanumeric characters.";
+                                                                    "It should start with alphabetic and end with alphanumeric characters." +
+                                                                    "Maximum length of project name is " + PROJECT_NAME_MAX_LENGTH + " characters";
 
     @FormParam("gitOrganization")
     @Pattern(message = "gitOrganization should follow consist only of alphanumeric characters, '-', '_' or '.' .",
@@ -48,6 +51,8 @@ public class LaunchProjectileInput implements LauncherProjectileContext {
     @NotNull(message = "projectName is required")
     @Pattern(message = PROJECT_NAME_VALIDATION_MESSAGE,
             regexp = PROJECT_NAME_REGEX)
+    @Size(message = PROJECT_NAME_VALIDATION_MESSAGE,
+            max = PROJECT_NAME_MAX_LENGTH)
     private String projectName;
 
     @FormParam("groupId")

--- a/web/src/test/java/io/fabric8/launcher/web/endpoints/inputs/LaunchProjectileInputTest.java
+++ b/web/src/test/java/io/fabric8/launcher/web/endpoints/inputs/LaunchProjectileInputTest.java
@@ -42,6 +42,19 @@ public class LaunchProjectileInputTest {
     }
 
     @Test
+    public void projectNameShouldNotExceedMaxLength() {
+        // GIVEN
+        launchProjectInput.setProjectName("test-123test-123test-123test-123test-123test-123test-123");
+
+        // WHEN
+        Set<ConstraintViolation<LaunchProjectileInput>> violations = validator.validate(launchProjectInput);
+
+        // THEN
+        assertThat(violations).isNotEmpty();
+        assertThat(hasMessage(violations, LaunchProjectileInput.PROJECT_NAME_VALIDATION_MESSAGE)).isTrue();
+    }
+
+    @Test
     public void projectNameShouldStartWithAlphabeticCharacters() {
         // GIVEN
         launchProjectInput.setProjectName("123Test");


### PR DESCRIPTION


### Why
If project name exceeds 49 characters length then Jenkins fails to execute the job.
See https://github.com/openshiftio/openshift.io/issues/2527#issuecomment-401681596 

### Description

To fix this issue added project constraints on project name length

### Checklist

- [X] I followed the contribution [guidelines](https://raw.githubusercontent.com/fabric8-launcher/launcher-backend/master/CONTRIBUTING.md).
- [ ] I created an [issue](https://github.com/fabric8-launcher/launcher-backend/issues/new) and used it in the commit message.
- [X] I have built the project locally prior to submission with `mvn clean install`.
- [X] I kept a clean commit log (no unnecessary commits, no merge commits).
- [X] I am happy with my contribution.
