### PR TITLE
 fixes project name length issue

### DIFF
--- a/addons/osio-addon/pom.xml
+++ b/addons/osio-addon/pom.xml
@@ -32,6 +32,16 @@
       <artifactId>launcher-service-openshift-impl</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.web</groupId>
+      <artifactId>javax.el</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/projectiles/context/OsioImportProjectileContext.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/projectiles/context/OsioImportProjectileContext.java
@@ -2,6 +2,7 @@ package io.fabric8.launcher.osio.projectiles.context;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
 import javax.ws.rs.FormParam;
 
 import io.fabric8.launcher.core.api.ProjectileContext;
@@ -9,6 +10,9 @@ import io.fabric8.launcher.core.api.ProjectileContext;
 import static io.fabric8.launcher.service.git.api.GitService.GIT_NAME_REGEXP;
 
 public class OsioImportProjectileContext implements ProjectileContext {
+
+    public static final int PROJECT_NAME_MAX_LENGTH = 49;
+    public static final String PROJECT_NAME_VALIDATION_MESSAGE = "Maximum length of project name is " + PROJECT_NAME_MAX_LENGTH + " characters";
 
     @FormParam("gitOrganization")
     @Pattern(message = "gitOrganization should follow consist only of alphanumeric characters, '-', '_' or '.' .",
@@ -27,6 +31,8 @@ public class OsioImportProjectileContext implements ProjectileContext {
             "and must consist of lower case alphanumeric characters, '-' or '.', and must start " +
             "and end with an alphanumeric character",
             regexp = "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*")
+    @Size(message = PROJECT_NAME_VALIDATION_MESSAGE,
+            max = PROJECT_NAME_MAX_LENGTH)
     private String projectName;
 
     @FormParam("pipeline")
@@ -55,5 +61,21 @@ public class OsioImportProjectileContext implements ProjectileContext {
 
     public String getSpaceId() {
         return spaceId;
+    }
+
+    public void setGitRepository(String gitRepository) {
+        this.gitRepository = gitRepository;
+    }
+
+    public void setProjectName(String projectName) {
+        this.projectName = projectName;
+    }
+
+    public void setSpaceId(String spaceId) {
+        this.spaceId = spaceId;
+    }
+
+    public void setPipelineId(String pipelineId) {
+        this.pipelineId = pipelineId;
     }
 }

--- a/addons/osio-addon/src/test/java/io/fabric8/launcher/osio/projectiles/context/OsioImportProjectileContextTest.java
+++ b/addons/osio-addon/src/test/java/io/fabric8/launcher/osio/projectiles/context/OsioImportProjectileContextTest.java
@@ -1,0 +1,72 @@
+package io.fabric8.launcher.osio.projectiles.context;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Created by hshinde on 7/4/18.
+ */
+public class OsioImportProjectileContextTest {
+
+    private Validator validator;
+
+    private OsioImportProjectileContext launchProjectInput;
+
+    @Before
+    public void init() {
+        initializeValidator();
+        initializeLaunchInputs();
+    }
+
+    @Test
+    public void shouldNotViolateProjectNameConstraints() {
+        // GIVEN
+        launchProjectInput.setProjectName("test-123");
+
+        // WHEN
+        Set<ConstraintViolation<OsioImportProjectileContext>> violations = validator.validate(launchProjectInput);
+
+        // THEN
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    public void projectNameShouldNotExceedMaxLength() {
+        // GIVEN
+        launchProjectInput.setProjectName("test-123test-123test-123test-123test-123test-123test-123");
+
+        // WHEN
+        Set<ConstraintViolation<OsioImportProjectileContext>> violations = validator.validate(launchProjectInput);
+
+        // THEN
+        assertThat(violations).isNotEmpty();
+        assertThat(hasMessage(violations, OsioImportProjectileContext.PROJECT_NAME_VALIDATION_MESSAGE)).isTrue();
+    }
+
+    private void initializeValidator() {
+        ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
+        this.validator = validatorFactory.getValidator();
+    }
+
+    private void initializeLaunchInputs() {
+        launchProjectInput = new OsioImportProjectileContext();
+        launchProjectInput.setGitRepository("foo");
+        launchProjectInput.setSpaceId("foo");
+        launchProjectInput.setPipelineId("foo");
+    }
+
+    private boolean hasMessage(Set<ConstraintViolation<OsioImportProjectileContext>> violations, String message) {
+        return violations
+                .stream()
+                .anyMatch(v -> v.getMessage().equalsIgnoreCase(message));
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,8 @@
     <version.rest.assured>3.1.0</version.rest.assured>
     <version.system.rules>1.18.0</version.system.rules>
     <version.mockito>2.19.0</version.mockito>
+    <version.hibernate-validator>5.1.1.Final</version.hibernate-validator>
+    <version.glassfish.javax.el>2.2.4</version.glassfish.javax.el>
   </properties>
 
   <modules>
@@ -305,7 +307,18 @@
         <artifactId>artemis-junit</artifactId>
         <version>${version.activemq.artemis}</version>
       </dependency>
+      <dependency>
+        <groupId>org.hibernate</groupId>
+        <artifactId>hibernate-validator</artifactId>
+        <version>${version.hibernate-validator}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish.web</groupId>
+        <artifactId>javax.el</artifactId>
+        <version>${version.glassfish.javax.el}</version>
+      </dependency>
     </dependencies>
+
   </dependencyManagement>
 
   <dependencies>

--- a/web/src/main/java/io/fabric8/launcher/web/endpoints/inputs/LaunchProjectileInput.java
+++ b/web/src/main/java/io/fabric8/launcher/web/endpoints/inputs/LaunchProjectileInput.java
@@ -2,7 +2,6 @@ package io.fabric8.launcher.web.endpoints.inputs;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
-import javax.validation.constraints.Size;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.HeaderParam;
@@ -20,10 +19,8 @@ import static io.fabric8.launcher.service.git.api.GitService.GIT_NAME_REGEXP;
 public class LaunchProjectileInput implements LauncherProjectileContext {
 
     public static final String PROJECT_NAME_REGEX = "^[a-zA-Z](?!.*--)(?!.*__)[a-zA-Z0-9-_]{2,38}[a-zA-Z0-9]$";
-    public static final int PROJECT_NAME_MAX_LENGTH = 49;
     public static final String PROJECT_NAME_VALIDATION_MESSAGE = "projectName should consist of only alphanumeric characters, '-' and '_'. " +
-                                                                    "It should start with alphabetic and end with alphanumeric characters." +
-                                                                    "Maximum length of project name is " + PROJECT_NAME_MAX_LENGTH + " characters";
+                                                                    "It should start with alphabetic and end with alphanumeric characters.";
 
     @FormParam("gitOrganization")
     @Pattern(message = "gitOrganization should follow consist only of alphanumeric characters, '-', '_' or '.' .",
@@ -51,8 +48,6 @@ public class LaunchProjectileInput implements LauncherProjectileContext {
     @NotNull(message = "projectName is required")
     @Pattern(message = PROJECT_NAME_VALIDATION_MESSAGE,
             regexp = PROJECT_NAME_REGEX)
-    @Size(message = PROJECT_NAME_VALIDATION_MESSAGE,
-            max = PROJECT_NAME_MAX_LENGTH)
     private String projectName;
 
     @FormParam("groupId")

--- a/web/src/test/java/io/fabric8/launcher/web/endpoints/inputs/LaunchProjectileInputTest.java
+++ b/web/src/test/java/io/fabric8/launcher/web/endpoints/inputs/LaunchProjectileInputTest.java
@@ -42,19 +42,6 @@ public class LaunchProjectileInputTest {
     }
 
     @Test
-    public void projectNameShouldNotExceedMaxLength() {
-        // GIVEN
-        launchProjectInput.setProjectName("test-123test-123test-123test-123test-123test-123test-123");
-
-        // WHEN
-        Set<ConstraintViolation<LaunchProjectileInput>> violations = validator.validate(launchProjectInput);
-
-        // THEN
-        assertThat(violations).isNotEmpty();
-        assertThat(hasMessage(violations, LaunchProjectileInput.PROJECT_NAME_VALIDATION_MESSAGE)).isTrue();
-    }
-
-    @Test
     public void projectNameShouldStartWithAlphabeticCharacters() {
         // GIVEN
         launchProjectInput.setProjectName("123Test");


### PR DESCRIPTION

### Why
If project name exceeds 49 characters length then Jenkins fails to execute the job.
See https://github.com/openshiftio/openshift.io/issues/2527#issuecomment-401681596 

Reverts the PR changes of https://github.com/fabric8-launcher/launcher-backend/pull/468. Updated the right class.

### Description

To fix this issue added project constraints on project name length

### Checklist

- [X] I followed the contribution [guidelines](https://raw.githubusercontent.com/fabric8-launcher/launcher-backend/master/CONTRIBUTING.md).
- [ ] I created an [issue](https://github.com/fabric8-launcher/launcher-backend/issues/new) and used it in the commit message.
- [X] I have built the project locally prior to submission with `mvn clean install`.
- [X] I kept a clean commit log (no unnecessary commits, no merge commits).
- [X] I am happy with my contribution.
