### PR TITLE
Reordered the launch process, code push first then webhook creation

### DIFF
--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioImportMissionControl.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioImportMissionControl.java
@@ -79,11 +79,12 @@ public class OsioImportMissionControl implements MissionControl<OsioImportProjec
 
         final BuildConfig buildConfig = openShiftSteps.createBuildConfig(projectile, repository);
 
-        // create webhook first so that push will trigger build
-        gitSteps.createWebHooks(projectile, repository);
-
-        // Push the changes to the imported repository
+        // push code changes first so that push event will not trigger build
+        // and we are already trigerring build later
         gitSteps.pushToGitRepository(projectile, repository);
+
+        // create webhook after push so that it will not trigger build
+        gitSteps.createWebHooks(projectile, repository);
 
         // Create jenkins config
         openShiftSteps.createJenkinsConfigMap(projectile, repository);

--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioLaunchMissionControl.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioLaunchMissionControl.java
@@ -75,14 +75,17 @@ public class OsioLaunchMissionControl implements MissionControl<OsioProjectileCo
 
         final BuildConfig buildConfig = openShiftSteps.createBuildConfig(projectile, repository);
 
-        // create webhook first so that push will trigger build
-        gitSteps.createWebHooks(projectile, repository);
-
+        // push code first so that push event will not trigger build
+        // and we are already trigerring build later
         if (projectile.isEmptyRepository()) {
             analytics.pushToGithubRepository(projectile);
         } else {
             gitSteps.pushToGitRepository(projectile, repository);
         }
+
+        // create webhook after push so that it will not trigger build
+        gitSteps.createWebHooks(projectile, repository);
+
         // Create jenkins config
         openShiftSteps.createJenkinsConfigMap(projectile, repository);
 

--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/web/endpoints/OsioImportEndpoint.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/web/endpoints/OsioImportEndpoint.java
@@ -53,7 +53,7 @@ public class OsioImportEndpoint {
         // No need to hold off the processing, return the status link immediately
         response.resume(ImmutableAsyncBoom.builder()
                                 .uuid(projectile.getId())
-                                .eventTypes(EnumSet.of(OPENSHIFT_CREATE, GITHUB_WEBHOOK, GITHUB_PUSHED, OPENSHIFT_PIPELINE))
+                                .eventTypes(EnumSet.of(OPENSHIFT_CREATE, GITHUB_PUSHED, GITHUB_WEBHOOK, OPENSHIFT_PIPELINE))
                                 .build());
         StopWatch stopWatch = new StopWatch();
         stopWatch.start();

--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/web/endpoints/OsioLaunchEndpoint.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/web/endpoints/OsioLaunchEndpoint.java
@@ -54,7 +54,7 @@ public class OsioLaunchEndpoint {
         // No need to hold off the processing, return the status link immediately
         response.resume(ImmutableAsyncBoom.builder()
                                 .uuid(projectile.getId())
-                                .eventTypes(EnumSet.of(GITHUB_CREATE, OPENSHIFT_CREATE, GITHUB_WEBHOOK, GITHUB_PUSHED, OPENSHIFT_PIPELINE))
+                                .eventTypes(EnumSet.of(GITHUB_CREATE, OPENSHIFT_CREATE, GITHUB_PUSHED, GITHUB_WEBHOOK, OPENSHIFT_PIPELINE))
                                 .build());
 
         StopWatch stopWatch = new StopWatch();


### PR DESCRIPTION
Pushing code later may trigger a build and two builds are getting triggered, so first push code
then create webhook and we are already triggering build later.
Fixes https://github.com/openshiftio/openshift.io/issues/3742
Fixes https://github.com/openshiftio/openshift.io/issues/3252

### Checklist

- [x] I followed the contribution [guidelines](https://raw.githubusercontent.com/fabric8-launcher/launcher-backend/master/CONTRIBUTING.md).
- [x] I created an [issue](https://github.com/fabric8-launcher/launcher-backend/issues/new) and used it in the commit message.
  I linked the PR to OSIO issues.
- [x] I have built the project locally prior to submission with `mvn clean install`.
- [x] I kept a clean commit log (no unnecessary commits, no merge commits).
- [x] I am happy with my contribution.
