### PR TITLE
fix(readme): adds section about Git LFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Please read the [Contributing Guide](./CONTRIBUTING.md) to help you make a great
 Setting up the environment
 --------------------------
 
+* As we are using `git bundle`s to test Git operations using in-memory Git server we switched to [Git LFS](https://git-lfs.github.com/). Follow the instruction there to install on your machine. Once you have that set up, enable it for the repository:
+
+```bash
+$ git lfs install
+$ git lfs pull
+```
 
 * You have to setup environment variables before you start the back-end. 
 


### PR DESCRIPTION
### Why

We have introduced Git LFS to manage large files (such as bundles) easily. We missed, however, the description in the README on how to enable it, as it's not an integral part of the default git installation. Without that, all tests which rely on the bundles are failing, because bundles are just LFS pointers. 

### Description

Updates README with the required section

### Checklist

- [x] I followed the contribution [guidelines](https://raw.githubusercontent.com/fabric8-launcher/launcher-backend/master/CONTRIBUTING.md).
- [ ] I created an [issue](https://github.com/fabric8-launcher/launcher-backend/issues/new) and used it in the commit message.
- [x] I have built the project locally prior to submission with `mvn clean install`.
- [x] I kept a clean commit log (no unnecessary commits, no merge commits).
- [x] I am happy with my contribution.
