### PR TITLE
fix(#509): renames codebase event

### DIFF
--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioStatusEventKind.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioStatusEventKind.java
@@ -8,7 +8,7 @@ import io.fabric8.launcher.core.api.events.StatusEventKind;
  */
 public enum OsioStatusEventKind implements StatusEventKind {
 
-    CODEBASE_CREATED("Setting OSIO Codebase");
+    CODEBASE_CREATED("Setting up your codebase");
 
     OsioStatusEventKind(String message) {
         this.message = message;


### PR DESCRIPTION
### Why

OSIO is not an official name and thus should not be used in the UI

### Description

Renames the event

Closes #509

### Checklist

- [x] I followed the contribution [guidelines](https://raw.githubusercontent.com/fabric8-launcher/launcher-backend/master/CONTRIBUTING.md).
- [x] I created an [issue](https://github.com/fabric8-launcher/launcher-backend/issues/new) and used it in the commit message.
- [ ] I have built the project locally prior to submission with `mvn clean install`.
- [x] I kept a clean commit log (no unnecessary commits, no merge commits).
- [x] I am happy with my contribution.
