### PR TITLE
fix: closes response on async consumption

### DIFF
--- a/base/src/main/java/io/fabric8/launcher/base/http/HttpClient.java
+++ b/base/src/main/java/io/fabric8/launcher/base/http/HttpClient.java
@@ -116,6 +116,8 @@ public class HttpClient {
                     future.complete(mapFunction.apply(response));
                 } catch (@SuppressWarnings("squid:S1181") final Throwable t) {
                     future.completeExceptionally(t);
+                } finally {
+                    response.close();
                 }
             }
         });
@@ -136,6 +138,8 @@ public class HttpClient {
                     future.complete(parseJson(jsonNodeFunction, response));
                 } catch (@SuppressWarnings("squid:S1181") final Throwable e) {
                     future.completeExceptionally(e);
+                } finally {
+                    response.close();
                 }
             }
         });


### PR DESCRIPTION
### Why

Not closing response on async complete might lead to resource leaks

### Description

Fixes response handling on `Async` executes.

### Checklist

- [x] I followed the contribution [guidelines](https://raw.githubusercontent.com/fabric8-launcher/launcher-backend/master/CONTRIBUTING.md).
- [ ] I created an [issue](https://github.com/fabric8-launcher/launcher-backend/issues/new) and used it in the commit message.
- [x] I have built the project locally prior to submission with `mvn clean install`.
- [x] I kept a clean commit log (no unnecessary commits, no merge commits).
- [x] I am happy with my contribution.
