### PR TITLE
fix(launch): Zip file name now correctly assumes the project name

### DIFF
--- a/core/core-api/src/main/java/io/fabric8/launcher/core/api/projectiles/context/CreateProjectileContext.java
+++ b/core/core-api/src/main/java/io/fabric8/launcher/core/api/projectiles/context/CreateProjectileContext.java
@@ -22,4 +22,6 @@ public interface CreateProjectileContext extends ProjectileContext {
 
     String getProjectVersion();
 
+    String getProjectName();
+
 }

--- a/core/core-api/src/main/java/io/fabric8/launcher/core/api/projectiles/context/LauncherProjectileContext.java
+++ b/core/core-api/src/main/java/io/fabric8/launcher/core/api/projectiles/context/LauncherProjectileContext.java
@@ -9,8 +9,6 @@ import io.fabric8.launcher.core.api.Projectile;
  */
 public interface LauncherProjectileContext extends CreateProjectileContext {
 
-    String getProjectName();
-
     String getGitOrganization();
 
     String getGitRepository();

--- a/core/core-impl/src/test/java/io/fabric8/launcher/core/impl/preparers/ChangeArquillianConfigurationPreparerIT.java
+++ b/core/core-impl/src/test/java/io/fabric8/launcher/core/impl/preparers/ChangeArquillianConfigurationPreparerIT.java
@@ -148,6 +148,11 @@ public class ChangeArquillianConfigurationPreparerIT {
       public String getProjectVersion() {
          return null;
       }
+
+      @Override
+      public String getProjectName() {
+         return null;
+      }
    }
 
    private static class TestRepoUrlFixer {

--- a/web/src/main/java/io/fabric8/launcher/web/endpoints/LaunchEndpoint.java
+++ b/web/src/main/java/io/fabric8/launcher/web/endpoints/LaunchEndpoint.java
@@ -1,6 +1,7 @@
 package io.fabric8.launcher.web.endpoints;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -61,11 +62,12 @@ public class LaunchEndpoint {
         CreateProjectile projectile = null;
         try {
             projectile = missionControl.prepare(zipProjectile);
-            byte[] zipContents = Paths.zip(zipProjectile.getArtifactId(), projectile.getProjectLocation());
+            String filename = Objects.toString(zipProjectile.getProjectName(), zipProjectile.getArtifactId());
+            byte[] zipContents = Paths.zip(filename, projectile.getProjectLocation());
             return Response
                     .ok(zipContents)
                     .type(APPLICATION_ZIP)
-                    .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + zipProjectile.getArtifactId() + ".zip\"")
+                    .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + ".zip\"")
                     .build();
         } finally {
             if (projectile != null) {

--- a/web/src/main/java/io/fabric8/launcher/web/endpoints/inputs/ZipProjectileInput.java
+++ b/web/src/main/java/io/fabric8/launcher/web/endpoints/inputs/ZipProjectileInput.java
@@ -36,6 +36,9 @@ public class ZipProjectileInput implements ZipProjectileContext {
     @DefaultValue("1.0.0")
     private String projectVersion;
 
+    @QueryParam("projectName")
+    private String projectName;
+
     @Override
     public Mission getMission() {
         return mission;
@@ -64,5 +67,10 @@ public class ZipProjectileInput implements ZipProjectileContext {
     @Override
     public String getProjectVersion() {
         return projectVersion;
+    }
+
+    @Override
+    public String getProjectName() {
+        return projectName;
     }
 }


### PR DESCRIPTION
Fallsback to ArtifactId if projectName is not provided

Fixes https://github.com/fabric8-launcher/launcher-planning/issues/168