### PR TITLE
Revert "fix: AsyncResponse.resume is not flushed until the OutputStream is closed"

### DIFF
--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/web/endpoints/OsioImportEndpoint.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/web/endpoints/OsioImportEndpoint.java
@@ -1,14 +1,11 @@
 package io.fabric8.launcher.osio.web.endpoints;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import javax.ws.rs.BeanParam;
 import javax.ws.rs.POST;
@@ -16,7 +13,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 
 import io.fabric8.launcher.core.api.ImmutableAsyncBoom;
@@ -52,17 +48,14 @@ public class OsioImportEndpoint {
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Secured
-    public void importRepository(@Valid @BeanParam OsioImportProjectileContext context, @Suspended AsyncResponse asyncResponse,
-                                 @Context HttpServletResponse response) throws IOException {
+    public void importRepository(@Valid @BeanParam OsioImportProjectileContext context, @Suspended AsyncResponse response) {
         OsioImportProjectile projectile = missionControl.prepare(context);
 
         // No need to hold off the processing, return the status link immediately
-        try (ServletOutputStream stream = response.getOutputStream()) {
-            asyncResponse.resume(ImmutableAsyncBoom.builder()
-                                         .uuid(projectile.getId())
-                                         .eventTypes(Arrays.asList(OPENSHIFT_CREATE, GITHUB_PUSHED, GITHUB_WEBHOOK, OPENSHIFT_PIPELINE, CODEBASE_CREATED))
-                                         .build());
-        }
+        response.resume(ImmutableAsyncBoom.builder()
+                                .uuid(projectile.getId())
+                                .eventTypes(Arrays.asList(OPENSHIFT_CREATE, GITHUB_PUSHED, GITHUB_WEBHOOK, OPENSHIFT_PIPELINE, CODEBASE_CREATED))
+                                .build());
         StopWatch stopWatch = new StopWatch();
         stopWatch.start();
         try {

--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/web/endpoints/OsioLaunchEndpoint.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/web/endpoints/OsioLaunchEndpoint.java
@@ -1,13 +1,10 @@
 package io.fabric8.launcher.osio.web.endpoints;
 
-import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import javax.ws.rs.BeanParam;
 import javax.ws.rs.POST;
@@ -15,7 +12,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 
 import io.fabric8.launcher.core.api.ImmutableAsyncBoom;
@@ -53,17 +49,14 @@ public class OsioLaunchEndpoint {
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Secured
-    public void launch(@Valid @BeanParam OsioProjectileContext context, @Suspended AsyncResponse asyncResponse,
-                       @Context HttpServletResponse response) throws IOException {
+    public void launch(@Valid @BeanParam OsioProjectileContext context, @Suspended AsyncResponse response) {
         OsioLaunchProjectile projectile = missionControl.prepare(context);
 
         // No need to hold off the processing, return the status link immediately
-        try (ServletOutputStream stream = response.getOutputStream()) {
-            asyncResponse.resume(ImmutableAsyncBoom.builder()
-                                         .uuid(projectile.getId())
-                                         .eventTypes(asList(GITHUB_CREATE, OPENSHIFT_CREATE, GITHUB_PUSHED, GITHUB_WEBHOOK, OPENSHIFT_PIPELINE, CODEBASE_CREATED))
-                                         .build());
-        }
+        response.resume(ImmutableAsyncBoom.builder()
+                                .uuid(projectile.getId())
+                                .eventTypes(asList(GITHUB_CREATE, OPENSHIFT_CREATE, GITHUB_PUSHED, GITHUB_WEBHOOK, OPENSHIFT_PIPELINE, CODEBASE_CREATED))
+                                .build());
 
         StopWatch stopWatch = new StopWatch();
         stopWatch.start();

--- a/web/src/main/java/io/fabric8/launcher/web/endpoints/LaunchEndpoint.java
+++ b/web/src/main/java/io/fabric8/launcher/web/endpoints/LaunchEndpoint.java
@@ -7,8 +7,6 @@ import java.util.logging.Logger;
 
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import javax.ws.rs.BeanParam;
 import javax.ws.rs.GET;
@@ -17,7 +15,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -83,8 +80,7 @@ public class LaunchEndpoint {
     @Path("/launch")
     @Secured
     @Produces(MediaType.APPLICATION_JSON)
-    public void launch(@Valid @BeanParam LaunchProjectileInput launchProjectileInput, @Suspended AsyncResponse asyncResponse,
-                       @Context HttpServletResponse response) throws IOException {
+    public void launch(@Valid @BeanParam LaunchProjectileInput launchProjectileInput, @Suspended AsyncResponse response) {
         CreateProjectile projectile = ImmutableLauncherCreateProjectile.builder()
                 .from(missionControl.prepare(launchProjectileInput))
                 .startOfStep(launchProjectileInput.getExecutionStep())
@@ -92,13 +88,10 @@ public class LaunchEndpoint {
                 .build();
 
         // No need to hold off the processing, return the status link immediately
-        // Need to close the response's OutputStream after resuming to automatically flush the contents
-        try (ServletOutputStream stream = response.getOutputStream()) {
-            asyncResponse.resume(ImmutableAsyncBoom.builder()
-                                         .uuid(projectile.getId())
-                                         .eventTypes(asList(LauncherStatusEventKind.values()))
-                                         .build());
-        }
+        response.resume(ImmutableAsyncBoom.builder()
+                                .uuid(projectile.getId())
+                                .eventTypes(asList(LauncherStatusEventKind.values()))
+                                .build());
 
         StopWatch stopWatch = new StopWatch();
         stopWatch.start();


### PR DESCRIPTION
This reverts commit 34ea7f459766ab1062a3b9736e1e4fb892794a28.



<Briefly explain why you made those changes (you can reference some issues here).>


<Please describe your changes here.>

Closes #...


- [ ] I followed the contribution [guidelines](https://raw.githubusercontent.com/fabric8-launcher/launcher-backend/master/CONTRIBUTING.md).
- [ ] I created an [issue](https://github.com/fabric8-launcher/launcher-backend/issues/new) and used it in the commit message.
- [ ] I have built the project locally prior to submission with `mvn clean install`.
- [ ] I kept a clean commit log (no unnecessary commits, no merge commits).
- [ ] I am happy with my contribution.