### PR TITLE
chore: documents app-type extraction from header

### DIFF
--- a/core/core-api/pom.xml
+++ b/core/core-api/pom.xml
@@ -27,6 +27,12 @@
       <groupId>io.fabric8.launcher</groupId>
       <artifactId>booster-catalog-service</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>io.fabric8.launcher</groupId>
+      <artifactId>launcher-base-test</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/core/core-api/src/main/java/io/fabric8/launcher/core/spi/Application.java
+++ b/core/core-api/src/main/java/io/fabric8/launcher/core/spi/Application.java
@@ -29,13 +29,22 @@ public @interface Application {
         LAUNCHER,
         OSIO;
 
+        /**
+         * Converts X-App HTTP header to corresponding ApplicationType instance based on case insensitive name.
+         * If header does not exist it defaults to LAUNCHER.
+         *
+         * @param request to extract application name from
+         * @return instance of ApplicationType
+         *
+         * @throws IllegalArgumentException if the header has wrong application name
+         */
         public static ApplicationType fromHeader(HttpServletRequest request) {
             // If X-App is not specified, assume fabric8-launcher
             final String app = Objects.toString(request.getHeader("X-App"), "launcher").toUpperCase();
             try {
                 return valueOf(app);
             } catch (IllegalArgumentException iae) {
-                throw new IllegalArgumentException("Header 'X-App' has an invalid value: " + app, iae);
+                throw new IllegalArgumentException("Unrecognized application. Header 'X-App' has an invalid value: " + app, iae);
             }
         }
     }

--- a/core/core-api/src/test/java/io/fabric8/launcher/core/spi/ApplicationTypeConversionTest.java
+++ b/core/core-api/src/test/java/io/fabric8/launcher/core/spi/ApplicationTypeConversionTest.java
@@ -1,0 +1,65 @@
+package io.fabric8.launcher.core.spi;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ApplicationTypeConversionTest {
+
+    @Test
+    public void should_convert_to_launcher_when_header_not_specified() {
+        // given
+        final HttpServletRequest requestWithoutHeader = mock(HttpServletRequest.class);
+        when(requestWithoutHeader.getHeader("X-App")).thenReturn(null);
+
+        // when
+        final Application.ApplicationType recognizedApp = Application.ApplicationType.fromHeader(requestWithoutHeader);
+
+        // then
+        assertThat(recognizedApp).isEqualTo(Application.ApplicationType.LAUNCHER);
+    }
+
+    @Test
+    public void should_convert_to_launcher_when_header_specified() {
+        // given
+        final HttpServletRequest requestWithoutHeader = mock(HttpServletRequest.class);
+        when(requestWithoutHeader.getHeader("X-App")).thenReturn("Launcher");
+
+        // when
+        final Application.ApplicationType recognizedApp = Application.ApplicationType.fromHeader(requestWithoutHeader);
+
+        // then
+        assertThat(recognizedApp).isEqualTo(Application.ApplicationType.LAUNCHER);
+    }
+
+    @Test
+    public void should_convert_to_osio_when_header_specified_ignoring_case() {
+        // given
+        final HttpServletRequest requestWithoutHeader = mock(HttpServletRequest.class);
+        when(requestWithoutHeader.getHeader("X-App")).thenReturn("OSio");
+
+        // when
+        final Application.ApplicationType recognizedApp = Application.ApplicationType.fromHeader(requestWithoutHeader);
+
+        // then
+        assertThat(recognizedApp).isEqualTo(Application.ApplicationType.OSIO);
+    }
+
+    @Test
+    public void should_throw_exception_when_header_set_to_unrecognized_app() {
+        // given
+        final HttpServletRequest requestWithoutHeader = mock(HttpServletRequest.class);
+        when(requestWithoutHeader.getHeader("X-App")).thenReturn("mockito");
+
+        // when
+        final Throwable throwable = catchThrowable(() -> Application.ApplicationType.fromHeader(requestWithoutHeader));
+
+        // then
+        assertThat(throwable).hasMessageContaining("Unrecognized application. Header 'X-App' has an invalid value: MOCKITO");
+    }
+}


### PR DESCRIPTION
### Why

We missed javadoc and tests for it in #557

### Checklist

- [x] I followed the contribution [guidelines](https://raw.githubusercontent.com/fabric8-launcher/launcher-backend/master/CONTRIBUTING.md).
- [ ] I created an [issue](https://github.com/fabric8-launcher/launcher-backend/issues/new) and used it in the commit message.
- [x] I have built the project locally prior to submission with `mvn clean install`.
- [x] I kept a clean commit log (no unnecessary commits, no merge commits).
- [x] I am happy with my contribution.
