### PR TITLE
fix: adds application type information based on which the key was loo…

### DIFF
--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/client/AuthPublicKeyProvider.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/client/AuthPublicKeyProvider.java
@@ -53,7 +53,11 @@ public class AuthPublicKeyProvider implements PublicKeyProvider {
                 .url(pathJoin(getAuthUrl(), "/api/token/keys?format=pem")).build();
         try {
             final Map<String, RSAPublicKey> publicKeys = httpClient.executeAndMap(request, AuthPublicKeyProvider::findKeys);
-            return Optional.ofNullable(Objects.requireNonNull(publicKeys).get(keyId));
+            final RSAPublicKey publicKey = Objects.requireNonNull(publicKeys).get(keyId);
+            if (publicKey == null) {
+                logger.log(Level.SEVERE, "Key not found for kid: " + keyId);
+            }
+            return Optional.ofNullable(publicKey);
         } catch (final Exception e) {
             logger.log(Level.SEVERE, "Error while fetching keys from OSIO auth for kid: " + keyId, e);
             return Optional.empty();

--- a/core/core-api/src/test/java/io/fabric8/launcher/core/spi/ApplicationTypeConversionTest.java
+++ b/core/core-api/src/test/java/io/fabric8/launcher/core/spi/ApplicationTypeConversionTest.java
@@ -27,11 +27,11 @@ public class ApplicationTypeConversionTest {
     @Test
     public void should_convert_to_launcher_when_header_specified() {
         // given
-        final HttpServletRequest requestWithoutHeader = mock(HttpServletRequest.class);
-        when(requestWithoutHeader.getHeader("X-App")).thenReturn("Launcher");
+        final HttpServletRequest requestWithLauncher = mock(HttpServletRequest.class);
+        when(requestWithLauncher.getHeader("X-App")).thenReturn("Launcher");
 
         // when
-        final Application.ApplicationType recognizedApp = Application.ApplicationType.fromHeader(requestWithoutHeader);
+        final Application.ApplicationType recognizedApp = Application.ApplicationType.fromHeader(requestWithLauncher);
 
         // then
         assertThat(recognizedApp).isEqualTo(Application.ApplicationType.LAUNCHER);
@@ -40,11 +40,11 @@ public class ApplicationTypeConversionTest {
     @Test
     public void should_convert_to_osio_when_header_specified_ignoring_case() {
         // given
-        final HttpServletRequest requestWithoutHeader = mock(HttpServletRequest.class);
-        when(requestWithoutHeader.getHeader("X-App")).thenReturn("OSio");
+        final HttpServletRequest requestWithOSIO = mock(HttpServletRequest.class);
+        when(requestWithOSIO.getHeader("X-App")).thenReturn("OSio");
 
         // when
-        final Application.ApplicationType recognizedApp = Application.ApplicationType.fromHeader(requestWithoutHeader);
+        final Application.ApplicationType recognizedApp = Application.ApplicationType.fromHeader(requestWithOSIO);
 
         // then
         assertThat(recognizedApp).isEqualTo(Application.ApplicationType.OSIO);
@@ -53,11 +53,11 @@ public class ApplicationTypeConversionTest {
     @Test
     public void should_throw_exception_when_header_set_to_unrecognized_app() {
         // given
-        final HttpServletRequest requestWithoutHeader = mock(HttpServletRequest.class);
-        when(requestWithoutHeader.getHeader("X-App")).thenReturn("mockito");
+        final HttpServletRequest requestWithUnsupportedApp = mock(HttpServletRequest.class);
+        when(requestWithUnsupportedApp.getHeader("X-App")).thenReturn("mockito");
 
         // when
-        final Throwable throwable = catchThrowable(() -> Application.ApplicationType.fromHeader(requestWithoutHeader));
+        final Throwable throwable = catchThrowable(() -> Application.ApplicationType.fromHeader(requestWithUnsupportedApp));
 
         // then
         assertThat(throwable).hasMessageContaining("Unrecognized application. Header 'X-App' has an invalid value: MOCKITO");

--- a/core/core-impl/src/main/java/io/fabric8/launcher/core/impl/identity/KeycloakPublicKeyProvider.java
+++ b/core/core-impl/src/main/java/io/fabric8/launcher/core/impl/identity/KeycloakPublicKeyProvider.java
@@ -56,7 +56,9 @@ public class KeycloakPublicKeyProvider implements PublicKeyProvider {
         try {
             final Map<String, RSAPublicKey> publicKeys = httpClient.executeAndMap(request, KeycloakPublicKeyProvider::findKeys);
             final RSAPublicKey publicKey = Objects.requireNonNull(publicKeys).get(keyId);
-
+            if (publicKey == null) {
+                logger.log(Level.SEVERE, "Key not found for kid: " + keyId);
+            }
             return Optional.ofNullable(publicKey);
         } catch (final Exception e) {
             logger.log(Level.SEVERE, "Error while fetching keys from keycloak for kid: " + keyId, e);


### PR DESCRIPTION
…ked up

### Why

To better know which key provider is used in case of error

### Checklist

- [x] I followed the contribution [guidelines](https://raw.githubusercontent.com/fabric8-launcher/launcher-backend/master/CONTRIBUTING.md).
- [ ] I created an [issue](https://github.com/fabric8-launcher/launcher-backend/issues/new) and used it in the commit message.
- [x] I have built the project locally prior to submission with `mvn clean install`.
- [x] I kept a clean commit log (no unnecessary commits, no merge commits).
- [x] I am happy with my contribution.
