### PR TITLE
feature(git): Support specifying the default git provider

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -126,6 +126,12 @@ objects:
                 name: launcher
                 key: launcher.backend.documentation.reload.token
                 optional: true
+          - name: LAUNCHER_BACKEND_GIT_PROVIDER
+            valueFrom:
+              configMapKeyRef:
+                name: launcher
+                key: launcher.backend.git.provider
+                optional: true
           - name: LAUNCHER_BACKEND_GIT_REPOSITORY_DESCRIPTION
             valueFrom:
               configMapKeyRef:

--- a/services/git-service-api/src/main/java/io/fabric8/launcher/service/git/spi/GitProvider.java
+++ b/services/git-service-api/src/main/java/io/fabric8/launcher/service/git/spi/GitProvider.java
@@ -7,6 +7,8 @@ import java.lang.annotation.Target;
 import javax.enterprise.util.AnnotationLiteral;
 import javax.inject.Qualifier;
 
+import io.fabric8.launcher.base.EnvironmentEnum;
+
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
@@ -20,6 +22,10 @@ import static java.lang.annotation.ElementType.TYPE;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({TYPE, FIELD, PARAMETER, METHOD})
 public @interface GitProvider {
+
+    enum GitProviderEnvVarSysPropNames implements EnvironmentEnum {
+        LAUNCHER_BACKEND_GIT_PROVIDER
+    }
 
     enum GitProviderType {
         GITHUB,


### PR DESCRIPTION
This introduces a LAUNCHER_GIT_PROVIDER environment variable to specify which Git provider to use in this backend

Fixes 566