### PR TITLE
fix: use project name instead of maven artifactId

### DIFF
--- a/core/core-impl/src/main/java/io/fabric8/launcher/core/impl/preparers/ChangeNodeJSMetadataPreparer.java
+++ b/core/core-impl/src/main/java/io/fabric8/launcher/core/impl/preparers/ChangeNodeJSMetadataPreparer.java
@@ -21,6 +21,7 @@ import javax.json.stream.JsonGenerator;
 import io.fabric8.launcher.booster.catalog.rhoar.RhoarBooster;
 import io.fabric8.launcher.core.api.ProjectileContext;
 import io.fabric8.launcher.core.api.projectiles.context.CoordinateCapable;
+import io.fabric8.launcher.core.api.projectiles.context.ProjectNameCapable;
 import io.fabric8.launcher.core.spi.ProjectilePreparer;
 
 /**
@@ -33,7 +34,7 @@ public class ChangeNodeJSMetadataPreparer implements ProjectilePreparer {
 
     @Override
     public void prepare(Path projectPath, RhoarBooster booster, ProjectileContext context) {
-        if (!(context instanceof CoordinateCapable)) {
+        if (!(context instanceof CoordinateCapable) && !(context instanceof ProjectNameCapable)) {
             return;
         }
 
@@ -41,7 +42,7 @@ public class ChangeNodeJSMetadataPreparer implements ProjectilePreparer {
         Path packageJsonPath = projectPath.resolve("package.json");
         if (Files.exists(packageJsonPath)) {
             JsonObjectBuilder job = Json.createObjectBuilder();
-            job.add("name", coordinateCapable.getArtifactId());
+            job.add("name", ((ProjectNameCapable)context).getProjectName());
             job.add("version", coordinateCapable.getProjectVersion());
             try (BufferedReader bufferedReader = Files.newBufferedReader(packageJsonPath);
                  JsonReader reader = Json.createReader(bufferedReader)) {

--- a/core/core-impl/src/test/java/io/fabric8/launcher/core/impl/preparers/ChangeNodeJSMetadataPreparerTest.java
+++ b/core/core-impl/src/test/java/io/fabric8/launcher/core/impl/preparers/ChangeNodeJSMetadataPreparerTest.java
@@ -1,0 +1,94 @@
+package io.fabric8.launcher.core.impl.preparers;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import io.fabric8.launcher.booster.catalog.rhoar.Mission;
+import io.fabric8.launcher.booster.catalog.rhoar.Runtime;
+import io.fabric8.launcher.booster.catalog.rhoar.Version;
+import io.fabric8.launcher.core.api.projectiles.context.LauncherProjectileContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ChangeNodeJSMetadataPreparerTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private Path projectPath;
+
+    @Before
+    public void setUp() throws Exception {
+        projectPath = temporaryFolder.newFolder().toPath();
+        Files.copy(getClass().getResourceAsStream("/package.json"), projectPath.resolve("package.json"));
+    }
+
+
+    @Test
+    public void should_update_version_and_name() throws Exception {
+        //given
+        ChangeNodeJSMetadataPreparer preparer = new ChangeNodeJSMetadataPreparer();
+
+        //when
+        preparer.prepare(projectPath, null, new TestProjectileContext());
+
+        //then
+        final File expectedResultFile = new File(getClass().getResource("/package-result.json").getFile());
+        final byte[] expected = Files.readAllBytes(expectedResultFile.toPath());
+        assertThat(projectPath.resolve("package.json")).exists().hasContent(new String(expected, Charset.defaultCharset()));
+    }
+
+    private static class TestProjectileContext implements LauncherProjectileContext {
+
+        @Override
+        public String getProjectName() {
+            return "nodejs-test";
+        }
+
+        @Override
+        public String getGitOrganization() {
+            return null;
+        }
+
+        @Override
+        public String getGitRepository() {
+            return null;
+        }
+
+        @Override
+        public String getGroupId() {
+            return null;
+        }
+
+        @Override
+        public String getArtifactId() {
+            return null;
+        }
+
+        @Override
+        public String getProjectVersion() {
+            return "1.0.0";
+        }
+
+        @Override
+        public Mission getMission() {
+            return null;
+        }
+
+        @Override
+        public Runtime getRuntime() {
+            return null;
+        }
+
+        @Override
+        public Version getRuntimeVersion() {
+            return null;
+        }
+    }
+}

--- a/core/core-impl/src/test/resources/package-result.json
+++ b/core/core-impl/src/test/resources/package-result.json
@@ -1,0 +1,5 @@
+{
+  "name":"nodejs-test",
+  "version":"1.0.0",
+  "description":"Minimal package json"
+}

--- a/core/core-impl/src/test/resources/package.json
+++ b/core/core-impl/src/test/resources/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "example",
+  "description": "Minimal package json",
+  "version": "0.0.1"
+}


### PR DESCRIPTION
### Why

Instead of creating a lot of if else logic on the front-end it's better just to use the project name as application name for node, as we don't need to fill out the maven artifactId

### Description

Use project name instead of artifactId in package.json

Fixes: https://errortracking.prod-preview.openshift.io/openshift_io/fabric8-launcher-backend/issues/9113/

### Checklist

- [x] I followed the contribution [guidelines](https://raw.githubusercontent.com/fabric8-launcher/launcher-backend/master/CONTRIBUTING.md).
- [ ] I created an [issue](https://github.com/fabric8-launcher/launcher-backend/issues/new) and used it in the commit message.
- [x] I have built the project locally prior to submission with `mvn clean install`.
- [x] I kept a clean commit log (no unnecessary commits, no merge commits).
- [ ] I am happy with my contribution.
