### PR TITLE
build(deps): bump version.thorntail from 2.2.0.Final to 2.2.1.Final

### DIFF
--- a/core/core-impl/pom.xml
+++ b/core/core-impl/pom.xml
@@ -39,6 +39,12 @@
     <dependency>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-jms-client</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.johnzon</groupId>
+          <artifactId>johnzon-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Test dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <maven.buildNumber.shortRevisionLength>7</maven.buildNumber.shortRevisionLength>
 
     <version.booster.catalog.service>45</version.booster.catalog.service>
-    <version.thorntail>2.2.0.Final</version.thorntail>
+    <version.thorntail>2.2.1.Final</version.thorntail>
     <version.jackson>2.9.7</version.jackson>
     <version.maven-model-helper>7</version.maven-model-helper>
 


### PR DESCRIPTION
Bumps `version.thorntail` from 2.2.0.Final to 2.2.1.Final.

Updates `bom-all` from 2.2.0.Final to 2.2.1.Final
- [Release notes](https://github.com/thorntail/thorntail/releases)
- [Commits](https://github.com/thorntail/thorntail/compare/2.2.0.Final...2.2.1.Final)

Updates `thorntail-maven-plugin` from 2.2.0.Final to 2.2.1.Final