### PR TITLE
Ensure webhooks are created only after github push is complete

### DIFF
--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioImportMissionControl.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioImportMissionControl.java
@@ -29,7 +29,7 @@ import io.fabric8.openshift.api.model.BuildConfig;
  * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
  */
 @Dependent
-public class OsioImportMissionControl implements MissionControl<OsioImportProjectileContext, OsioImportProjectile>, GitEventListener{
+public class OsioImportMissionControl implements MissionControl<OsioImportProjectileContext, OsioImportProjectile>, GitEventListener {
 
     @Inject
     private GitSteps gitSteps;
@@ -74,6 +74,9 @@ public class OsioImportMissionControl implements MissionControl<OsioImportProjec
      */
     @Override
     public Boom launch(OsioImportProjectile projectile) {
+        // Sets the listener to be notified for git steps events
+        gitSteps.setListener(this);
+
         // Make sure that cd-github is created in Openshift
         openShiftSteps.ensureCDGithubSecretExists();
 
@@ -100,10 +103,10 @@ public class OsioImportMissionControl implements MissionControl<OsioImportProjec
                 .createdProject(ImmutableOpenShiftProject.builder().name(projectile.getOpenShiftProjectName()).build())
                 .build();
     }
-    
+
     @Override
-    public void pushToGitRepositoryCompleted(OsioProjectile projectile, GitRepository repository) {
-    	// create webhook after push so that it will not trigger build
-    	gitSteps.createWebHooks(projectile, repository);
+    public void pushEventNotification(OsioProjectile projectile, GitRepository repository) {
+        // create webhook after push so that it will not trigger build
+        gitSteps.createWebHooks(projectile, repository);
     }
 }

--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioImportMissionControl.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioImportMissionControl.java
@@ -84,7 +84,7 @@ public class OsioImportMissionControl implements MissionControl<OsioImportProjec
 
         final BuildConfig buildConfig = openShiftSteps.createBuildConfig(projectile, repository);
 
-        // push code changes first so that push event will not trigger build
+        // Push code changes first so that push event will not trigger build
         // and we are already trigerring build later
         gitSteps.pushToGitRepository(projectile, repository);
 
@@ -106,7 +106,7 @@ public class OsioImportMissionControl implements MissionControl<OsioImportProjec
 
     @Override
     public void pushEventNotification(OsioProjectile projectile, GitRepository repository) {
-        // create webhook after push so that it will not trigger build
+        // Create webhook after push so that it will not trigger build
         gitSteps.createWebHooks(projectile, repository);
     }
 }

--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioImportMissionControl.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioImportMissionControl.java
@@ -15,7 +15,9 @@ import io.fabric8.launcher.osio.client.OsioWitClient;
 import io.fabric8.launcher.osio.client.Space;
 import io.fabric8.launcher.osio.projectiles.ImmutableOsioImportProjectile;
 import io.fabric8.launcher.osio.projectiles.OsioImportProjectile;
+import io.fabric8.launcher.osio.projectiles.OsioProjectile;
 import io.fabric8.launcher.osio.projectiles.context.OsioImportProjectileContext;
+import io.fabric8.launcher.osio.steps.GitEventListener;
 import io.fabric8.launcher.osio.steps.GitSteps;
 import io.fabric8.launcher.osio.steps.OpenShiftSteps;
 import io.fabric8.launcher.osio.steps.WitSteps;
@@ -27,7 +29,7 @@ import io.fabric8.openshift.api.model.BuildConfig;
  * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
  */
 @Dependent
-public class OsioImportMissionControl implements MissionControl<OsioImportProjectileContext, OsioImportProjectile> {
+public class OsioImportMissionControl implements MissionControl<OsioImportProjectileContext, OsioImportProjectile>, GitEventListener{
 
     @Inject
     private GitSteps gitSteps;
@@ -83,9 +85,6 @@ public class OsioImportMissionControl implements MissionControl<OsioImportProjec
         // and we are already trigerring build later
         gitSteps.pushToGitRepository(projectile, repository);
 
-        // create webhook after push so that it will not trigger build
-        gitSteps.createWebHooks(projectile, repository);
-
         // Create jenkins config
         openShiftSteps.createJenkinsConfigMap(projectile, repository);
 
@@ -100,5 +99,11 @@ public class OsioImportMissionControl implements MissionControl<OsioImportProjec
                 .createdRepository(repository)
                 .createdProject(ImmutableOpenShiftProject.builder().name(projectile.getOpenShiftProjectName()).build())
                 .build();
+    }
+    
+    @Override
+    public void pushToGitRepositoryCompleted(OsioProjectile projectile, GitRepository repository) {
+    	// create webhook after push so that it will not trigger build
+    	gitSteps.createWebHooks(projectile, repository);
     }
 }

--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioLaunchMissionControl.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioLaunchMissionControl.java
@@ -74,7 +74,7 @@ public class OsioLaunchMissionControl implements MissionControl<OsioProjectileCo
 
         final BuildConfig buildConfig = openShiftSteps.createBuildConfig(projectile, repository);
 
-        // push code first so that push event will not trigger build
+        // Push code first so that push event will not trigger build
         // and we are already trigerring build later
         gitSteps.pushToGitRepository(projectile, repository);
 
@@ -96,7 +96,7 @@ public class OsioLaunchMissionControl implements MissionControl<OsioProjectileCo
 
     @Override
     public void pushEventNotification(OsioProjectile projectile, GitRepository repository) {
-        // create webhook after push so that it will not trigger build
+        // Create webhook after push so that it will not trigger build
         gitSteps.createWebHooks(projectile, repository);
     }
 }

--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioLaunchMissionControl.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioLaunchMissionControl.java
@@ -64,6 +64,9 @@ public class OsioLaunchMissionControl implements MissionControl<OsioProjectileCo
 
     @Override
     public Boom launch(OsioLaunchProjectile projectile) {
+        // Sets the listener to be notified for git steps events
+        gitSteps.setListener(this);
+
         // Make sure that cd-github is created in Openshift
         openShiftSteps.ensureCDGithubSecretExists();
 
@@ -90,10 +93,10 @@ public class OsioLaunchMissionControl implements MissionControl<OsioProjectileCo
                 .createdProject(ImmutableOpenShiftProject.builder().name(projectile.getOpenShiftProjectName()).build())
                 .build();
     }
-    
+
     @Override
-    public void pushToGitRepositoryCompleted(OsioProjectile projectile, GitRepository repository) {
-    	// create webhook after push so that it will not trigger build
-    	gitSteps.createWebHooks(projectile, repository);
+    public void pushEventNotification(OsioProjectile projectile, GitRepository repository) {
+        // create webhook after push so that it will not trigger build
+        gitSteps.createWebHooks(projectile, repository);
     }
 }

--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioLaunchMissionControl.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioLaunchMissionControl.java
@@ -93,6 +93,7 @@ public class OsioLaunchMissionControl implements MissionControl<OsioProjectileCo
     
     @Override
     public void pushToGitRepositoryCompleted(OsioProjectile projectile, GitRepository repository) {
-        gitSteps.createWebHooks(projectile, repository);
+    	// create webhook after push so that it will not trigger build
+    	gitSteps.createWebHooks(projectile, repository);
     }
 }

--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioLaunchMissionControl.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioLaunchMissionControl.java
@@ -1,8 +1,5 @@
 package io.fabric8.launcher.osio;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
@@ -31,7 +28,7 @@ import io.fabric8.openshift.api.model.BuildConfig;
  */
 @Dependent
 public class OsioLaunchMissionControl implements MissionControl<OsioProjectileContext, OsioLaunchProjectile>, GitEventListener  {
-    private List<GitEventListener> listeners = new ArrayList<GitEventListener>();
+
     @Inject
     private DefaultMissionControl missionControl;
 

--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/steps/GitEventListener.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/steps/GitEventListener.java
@@ -1,0 +1,9 @@
+package io.fabric8.launcher.osio.steps;
+
+import io.fabric8.launcher.osio.projectiles.OsioProjectile;
+import io.fabric8.launcher.service.git.api.GitRepository;
+
+public interface GitEventListener {
+
+    void pushToGitRepositoryCompleted(OsioProjectile projectile, GitRepository repository);
+}

--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/steps/GitEventListener.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/steps/GitEventListener.java
@@ -3,7 +3,22 @@ package io.fabric8.launcher.osio.steps;
 import io.fabric8.launcher.osio.projectiles.OsioProjectile;
 import io.fabric8.launcher.service.git.api.GitRepository;
 
+/**
+ * An interface used to for notifications related
+ * to git steps.
+ *
+ */
 public interface GitEventListener {
 
-    void pushToGitRepositoryCompleted(OsioProjectile projectile, GitRepository repository);
+    /**
+     * The callback to be implemented by listeners who are
+     * interested in knowing when gitSteps.pushToGitRepository()
+     * has been completed.
+     *
+     * @param projectile
+     *          The projectile used. Used to create web hooks.
+     * @param repository
+     *          The git repository to be used. Used to create web hooks.
+     */
+    void pushEventNotification(OsioProjectile projectile, GitRepository repository);
 }

--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/steps/GitSteps.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/steps/GitSteps.java
@@ -37,7 +37,7 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 @Dependent
 public class GitSteps {
     private static final Logger log = Logger.getLogger(GitSteps.class.getName());
-    private GitEventListener ie;
+    private GitEventListener gitEventListener;
 
     @Inject
     private GitService gitService;
@@ -85,7 +85,7 @@ public class GitSteps {
             gitService.push(repository, projectLocation);
         }
         projectile.getEventConsumer().accept(new StatusMessageEvent(projectile.getId(), GITHUB_PUSHED));
-        ie.pushToGitRepositoryCompleted(projectile, repository);
+        gitEventListener.pushToGitRepositoryCompleted(projectile, repository);
     }
 
     /**

--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/steps/GitSteps.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/steps/GitSteps.java
@@ -37,6 +37,7 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 @Dependent
 public class GitSteps {
     private static final Logger log = Logger.getLogger(GitSteps.class.getName());
+    private GitEventListener ie;
 
     @Inject
     private GitService gitService;
@@ -84,6 +85,7 @@ public class GitSteps {
             gitService.push(repository, projectLocation);
         }
         projectile.getEventConsumer().accept(new StatusMessageEvent(projectile.getId(), GITHUB_PUSHED));
+        ie.pushToGitRepositoryCompleted(projectile, repository);
     }
 
     /**

--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/steps/GitSteps.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/steps/GitSteps.java
@@ -85,7 +85,9 @@ public class GitSteps {
             gitService.push(repository, projectLocation);
         }
         projectile.getEventConsumer().accept(new StatusMessageEvent(projectile.getId(), GITHUB_PUSHED));
-        gitEventListener.pushToGitRepositoryCompleted(projectile, repository);
+
+        // notify listener that pushToGitRepository has completed
+        gitEventListener.pushEventNotification(projectile, repository);
     }
 
     /**
@@ -110,6 +112,17 @@ public class GitSteps {
 
     public GitRepository findRepository(OsioProjectile projectile) {
         return findRepository(projectile.getGitOrganization(), projectile.getGitRepositoryName());
+    }
+
+    /**
+     * Sets the listener to be notified when
+     * a git steps event occurs.
+     *
+     * @param listener
+     *          The listener to be notified
+     */
+    public void setListener(GitEventListener listener) {
+        this.gitEventListener = listener;
     }
 
     private GitRepository findRepository(String organization, String repositoryName) {

--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/steps/GitSteps.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/steps/GitSteps.java
@@ -86,7 +86,7 @@ public class GitSteps {
         }
         projectile.getEventConsumer().accept(new StatusMessageEvent(projectile.getId(), GITHUB_PUSHED));
 
-        // notify listener that pushToGitRepository has completed
+        // Notify listener that pushToGitRepository has completed
         gitEventListener.pushEventNotification(projectile, repository);
     }
 


### PR DESCRIPTION
### Why

Potential fix for: https://github.com/openshiftio/openshift.io/issues/3742

According to the following comment by @piyush-garg the builds might be triggered twice intermittently due to the createWebHooks(...) method being called prior to the pushToGitRepository(...) method completing: https://github.com/openshiftio/openshift.io/issues/3742#issuecomment-447838579

### Description

The solution implemented is a simple callback to listeners who are interested in knowing when the push has completed. Once the callback is called, the createWebHooks(...) method is invoked. 

Was tested to ensure that everything continues to work normally. However, unsure if this will fix the issue as it has been proven difficult to reproduce locally:
![screenshot from 2018-12-19 14-02-03](https://user-images.githubusercontent.com/40298444/50244066-fa433200-039c-11e9-866f-92df1c115629.png)

Closes #3742
https://github.com/openshiftio/openshift.io/issues/3742

### Checklist

- [ ] I followed the contribution [guidelines](https://raw.githubusercontent.com/fabric8-launcher/launcher-backend/master/CONTRIBUTING.md).
- [ ] I created an [issue](https://github.com/fabric8-launcher/launcher-backend/issues/new) and used it in the commit message.
- [ ] I have built the project locally prior to submission with `mvn clean install`.
- [ ] I kept a clean commit log (no unnecessary commits, no merge commits).
- [ ] I am happy with my contribution.
