### PR TITLE
changing order of events

### DIFF
--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioImportMissionControl.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioImportMissionControl.java
@@ -79,11 +79,10 @@ public class OsioImportMissionControl implements MissionControl<OsioImportProjec
 
         final BuildConfig buildConfig = openShiftSteps.createBuildConfig(projectile, repository);
 
-        // create webhook after push so that it will not trigger build
+        // Create webhook before push
         gitSteps.createWebHooks(projectile, repository);
 
-        // push code changes first so that push event will not trigger build
-        // and we are already trigerring build later
+        // Push code changes after so that push event will trigger build
         gitSteps.pushToGitRepository(projectile, repository);
 
         // Create jenkins config

--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioImportMissionControl.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioImportMissionControl.java
@@ -79,12 +79,12 @@ public class OsioImportMissionControl implements MissionControl<OsioImportProjec
 
         final BuildConfig buildConfig = openShiftSteps.createBuildConfig(projectile, repository);
 
+        // create webhook after push so that it will not trigger build
+        gitSteps.createWebHooks(projectile, repository);
+
         // push code changes first so that push event will not trigger build
         // and we are already trigerring build later
         gitSteps.pushToGitRepository(projectile, repository);
-
-        // create webhook after push so that it will not trigger build
-        gitSteps.createWebHooks(projectile, repository);
 
         // Create jenkins config
         openShiftSteps.createJenkinsConfigMap(projectile, repository);

--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioLaunchMissionControl.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioLaunchMissionControl.java
@@ -69,11 +69,10 @@ public class OsioLaunchMissionControl implements MissionControl<OsioProjectileCo
 
         final BuildConfig buildConfig = openShiftSteps.createBuildConfig(projectile, repository);
 
-        // create webhook after push so that it will not trigger build
+        // Create webhook before push
         gitSteps.createWebHooks(projectile, repository);
 
-        // push code first so that push event will not trigger build
-        // and we are already trigerring build later
+        // Push code after so that push event will trigger build
         gitSteps.pushToGitRepository(projectile, repository);
 
         // Create jenkins config

--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioLaunchMissionControl.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioLaunchMissionControl.java
@@ -69,12 +69,12 @@ public class OsioLaunchMissionControl implements MissionControl<OsioProjectileCo
 
         final BuildConfig buildConfig = openShiftSteps.createBuildConfig(projectile, repository);
 
+        // create webhook after push so that it will not trigger build
+        gitSteps.createWebHooks(projectile, repository);
+
         // push code first so that push event will not trigger build
         // and we are already trigerring build later
         gitSteps.pushToGitRepository(projectile, repository);
-
-        // create webhook after push so that it will not trigger build
-        gitSteps.createWebHooks(projectile, repository);
 
         // Create jenkins config
         openShiftSteps.createJenkinsConfigMap(projectile, repository);


### PR DESCRIPTION
### Why

Potential fix for: openshiftio/openshift.io#3742

Unsure if this change is a good one to make as there are comments in the code which outline the order and perhaps indicate that there was an issue when the order was reversed...? Will fix the comments if this is what we agree to try!

```
        // create webhook after push so that it will not trigger build
        gitSteps.createWebHooks(projectile, repository);

        // push code changes first so that push event will not trigger build
        // and we are already trigerring build later
        gitSteps.pushToGitRepository(projectile, repository);

```
### Description

Inverting order: https://github.com/fabric8-launcher/launcher-backend/pull/610#issuecomment-449319572

Closes #3742

### Checklist

- [ ] I followed the contribution [guidelines](https://raw.githubusercontent.com/fabric8-launcher/launcher-backend/master/CONTRIBUTING.md).
- [ ] I created an [issue](https://github.com/fabric8-launcher/launcher-backend/issues/new) and used it in the commit message.
- [ ] I have built the project locally prior to submission with `mvn clean install`.
- [ ] I kept a clean commit log (no unnecessary commits, no merge commits).
- [ ] I am happy with my contribution.
