### PR TITLE
fix(github): Disable internal HTTP Client cache when hitting Github

### DIFF
--- a/services/git-service-impl/src/main/java/io/fabric8/launcher/service/git/github/KohsukeGitHubService.java
+++ b/services/git-service-impl/src/main/java/io/fabric8/launcher/service/git/github/KohsukeGitHubService.java
@@ -252,6 +252,8 @@ public final class KohsukeGitHubService extends AbstractGitService implements Gi
             if (!repoName.contains("/")) {
                 repoName = delegate.getMyself().getLogin() + "/" + repoName;
             }
+            // Make sure that repository is available
+            waitForRepository(repoName);
             repo = delegate.getRepository(repoName);
         } catch (final IOException ioe) {
             throw new RuntimeException(ioe);

--- a/services/git-service-impl/src/main/java/io/fabric8/launcher/service/git/github/KohsukeGitHubServiceFactory.java
+++ b/services/git-service-impl/src/main/java/io/fabric8/launcher/service/git/github/KohsukeGitHubServiceFactory.java
@@ -17,6 +17,7 @@ import io.fabric8.launcher.service.git.api.GitService;
 import io.fabric8.launcher.service.git.api.GitServiceFactory;
 import io.fabric8.launcher.service.git.github.api.GitHubEnvironment;
 import io.fabric8.launcher.service.git.spi.GitProvider;
+import okhttp3.OkHttpClient;
 import org.kohsuke.github.AbuseLimitHandler;
 import org.kohsuke.github.GitHub;
 import org.kohsuke.github.GitHubBuilder;
@@ -80,10 +81,13 @@ public class KohsukeGitHubServiceFactory implements GitServiceFactory {
 
         final GitHub gitHub;
         try {
+            // Disable Cache completely when accessing Github
+            OkHttpClient client = httpClient.get().getClient()
+                    .newBuilder().cache(null).build();
             @SuppressWarnings("deprecation") final GitHubBuilder ghb = new GitHubBuilder()
                     .withAbuseLimitHandler(AbuseLimitHandler.FAIL)
                     .withRateLimitHandler(RateLimitHandler.FAIL)
-                    .withConnector(new OkHttp3Connector(new okhttp3.OkUrlFactory(httpClient.get().getClient())));
+                    .withConnector(new OkHttp3Connector(new okhttp3.OkUrlFactory(client)));
             identity.accept(new IdentityVisitor() {
                 @Override
                 public void visit(TokenIdentity token) {


### PR DESCRIPTION
This should resolve sporadic 404 when looking up repositories while creating webhooks

See https://github.com/openshiftio/openshift.io/issues/4696