### PR TITLE
Chore: Add Golang stack

### DIFF
--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/che/CheStack.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/che/CheStack.java
@@ -21,7 +21,8 @@ public enum CheStack {
     SpringBoot("spring-boot", "Spring Boot"),
     WildFlySwarm("wildfly-swarm", "WildFly Swarm"),
     JavaCentOS("java-centos", "Java"),
-    NodeJS("nodejs-centos", "NodeJS");
+    NodeJS("nodejs-centos", "NodeJS"),
+    Golang("go-default", "Golang");
 
     private final String id;
     private final String name;

--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/che/CheStackDetector.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/che/CheStackDetector.java
@@ -72,12 +72,18 @@ public final class CheStackDetector {
             } catch (Exception e) {
                 LOG.log(Level.SEVERE, "Error while parsing pom.xml", e);
             }
-        } else {
-            Path packageJson = projectLocation.resolve("package.json");
-            if (Files.exists(packageJson)) {
-                return CheStack.NodeJS;
-            }
         }
+
+        Path packageJson = projectLocation.resolve("package.json");
+        if (Files.exists(packageJson)) {
+            return CheStack.NodeJS;
+        }
+
+        Path mainFile = projectLocation.resolve("main.go");
+        if (Files.exists(mainFile)) {
+            return CheStack.Golang;
+        }
+
         // TODO assume Java?
         return CheStack.JavaCentOS;
     }

--- a/addons/osio-addon/src/test/java/io/fabric8/launcher/osio/che/CheStackDetectorTest.java
+++ b/addons/osio-addon/src/test/java/io/fabric8/launcher/osio/che/CheStackDetectorTest.java
@@ -36,4 +36,19 @@ public class CheStackDetectorTest {
         Assertions.assertThat(cheStack).isEqualTo(CheStack.SpringBoot);
     }
 
+    @Test
+    public void shouldDetectAsNodeJS() throws Exception {
+        URL resource = getClass().getResource("nodejs/package.json");
+        Path projectPath = Paths.get(resource.toURI()).getParent();
+        CheStack cheStack = CheStackDetector.detectCheStack(projectPath);
+        Assertions.assertThat(cheStack).isEqualTo(CheStack.NodeJS);
+    }
+
+    @Test
+    public void shouldDetectAsGolang() throws Exception {
+        URL resource = getClass().getResource("golang/main.go");
+        Path projectPath = Paths.get(resource.toURI()).getParent();
+        CheStack cheStack = CheStackDetector.detectCheStack(projectPath);
+        Assertions.assertThat(cheStack).isEqualTo(CheStack.Golang);
+    }
 }

--- a/addons/osio-addon/src/test/resources/io/fabric8/launcher/osio/che/golang/main.go
+++ b/addons/osio-addon/src/test/resources/io/fabric8/launcher/osio/che/golang/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+)
+
+var isOnline = true
+
+func main() {
+	http.HandleFunc("/api/greeting", greeting)
+	http.HandleFunc("/api/stop", stop)
+	http.HandleFunc("/api/health", health)
+	fmt.Println("Web server running on port 8080")
+
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}
+
+func greeting(w http.ResponseWriter, r *http.Request) {
+	if isOnline {
+		message := "World"
+		if m := r.FormValue("name"); m != "" {
+			message = m
+		}
+		fmt.Fprintf(w, "Hello %s!", message)
+		return
+	}
+	w.WriteHeader(503)
+	w.Write([]byte("Not Online"))
+}
+
+func stop(w http.ResponseWriter, r *http.Request) {
+	isOnline = false
+	w.Write([]byte("Stopping HTTP Server"))
+}
+
+func health(w http.ResponseWriter, r *http.Request) {
+	if isOnline {
+		w.WriteHeader(200)
+		return
+	}
+	w.WriteHeader(500)
+}

--- a/addons/osio-addon/src/test/resources/io/fabric8/launcher/osio/che/nodejs/package.json
+++ b/addons/osio-addon/src/test/resources/io/fabric8/launcher/osio/che/nodejs/package.json
@@ -1,0 +1,73 @@
+{
+    "name": "nodejs-health-check",
+    "version": "2.0.2",
+    "author": "Red Hat, Inc.",
+    "license": "Apache-2.0",
+    "scripts": {
+        "test": "tape test/*.js | tap-spec",
+        "test:integration": "tape test/integration/*.js | tap-spec",
+        "test:integration:undeploy": "nodeshift --strictSSL=false undeploy",
+        "lint": "xo",
+        "coverage": "nyc npm test",
+        "coveralls": "nyc npm test && nyc report --reporter=text-lcov | coveralls",
+        "ci": "npm run lint && npm run coveralls",
+        "dependencyCheck": "szero . --ci",
+        "release": "standard-version -a",
+        "openshift": "nodeshift --strictSSL=false --nodeVersion=10.x",
+        "postinstall": "license-reporter report -s && license-reporter save -s --xml licenses.xml",
+        "start": "node ."
+    },
+    "main": "./bin/www",
+    "standard-version": {
+        "scripts": {
+            "postbump": "npm run postinstall && node release.js",
+            "precommit": "git add .openshiftio/application.yaml licenses/"
+        }
+    },
+    "xo": {
+        "space": 2,
+        "rules": {
+            "space-before-function-paren": [
+                "error",
+                "always"
+            ]
+        }
+    },
+    "files": [
+        "package.json",
+        "app.js",
+        "public",
+        "bin",
+        "LICENSE",
+        "licenses"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/nodeshift-starters/nodejs-health-check.git"
+    },
+    "bugs": {
+        "url": "https://github.com/nodeshift-starters/nodejs-health-check/issues"
+    },
+    "homepage": "https://github.com/nodeshift-starters/nodejs-health-check",
+    "devDependencies": {
+        "coveralls": "^3.0.0",
+        "js-yaml": "^3.10.0",
+        "nodeshift": "~2.0.0",
+        "nyc": "~12.0.2",
+        "proxyquire": "^2.0.0",
+        "rhoaster": "~0.2.0",
+        "standard-version": "^4.3.0",
+        "supertest": "^3.0.0",
+        "szero": "^1.0.0",
+        "tap-spec": "~5.0.0",
+        "tape": "~4.9.0",
+        "xo": "~0.22.0"
+    },
+    "dependencies": {
+        "body-parser": "^1.18.2",
+        "debug": "^4.0.1",
+        "express": "4.16.0",
+        "kube-probe": "^0.3.1",
+        "license-reporter": "^1.2.0"
+    }
+}


### PR DESCRIPTION
### Why
The Golang stack was missing. The Golang boosters cannot run with node/java che stacks.

### Description
This PR 
- Adds new Golang enum to CheStacks
- Updates CheStackDetector to check for golang stack
