### PR TITLE
Use top-level recommended extension pack for Camel #649

### DIFF
--- a/core/core-impl/src/main/resources/vscode/fuse/extensions.json
+++ b/core/core-impl/src/main/resources/vscode/fuse/extensions.json
@@ -3,13 +3,7 @@
     // for the documentation about the extensions.json format
     "recommendations": [
         // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
-        "camel-tooling.vscode-apache-camel",
-        "redhat.java",
-        "vscjava.vscode-java-debug",
-        "vscjava.vscode-java-test",
-        "vscjava.vscode-maven",
-        "redhat.vscode-openshift-connector",
-        "redhat.fabric8-analytics",
-        "Pivotal.vscode-spring-boot"
+        "camel-tooling.apache-camel-extension-pack",
+        "redhat.fabric8-analytics"
     ]
 }


### PR DESCRIPTION
it is reducing the number of "recommended" extension that the user will
see and then will reduce the number of click that he/she will need to do
to install the recommended extension to work on the project

### Description

Camel Extension Pack have these dependencies:
https://github.com/camel-tooling/vscode-camel-extension-pack/blob/bbea1b162fa9c341a670d5c6aec9e6962ee3720a/package.json#L20-L25

Camel Extension pack have dependencies on the Java Extension pack which contains the following extensions:
https://github.com/Microsoft/vscode-java-pack/blob/b7d845d2ff783f3cc95c70573c7d0674f50f1bb8/package.json#L83-L88

Closes #649 

### Checklist

- [x] I followed the contribution [guidelines](https://raw.githubusercontent.com/fabric8-launcher/launcher-backend/master/CONTRIBUTING.md).
- [x] I created an [issue](https://github.com/fabric8-launcher/launcher-backend/issues/new) and used it in the commit message.
- [ ] I have built the project locally prior to submission with `mvn clean install`.
- [x] I kept a clean commit log (no unnecessary commits, no merge commits).
- [ ] I am happy with my contribution.
