### PR TITLE
Trigger build before adding webhook

### DIFF
--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioImportMissionControl.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioImportMissionControl.java
@@ -85,13 +85,11 @@ public class OsioImportMissionControl implements MissionControl<OsioImportProjec
 
         final BuildConfig buildConfig = openShiftSteps.createBuildConfig(projectile, repository);
 
-        // Create webhook before push
-        gitSteps.createWebHooks(projectile, repository);
-
-        // Push code changes after so that push event will trigger build
+        // Push code changes to github
         gitSteps.pushToGitRepository(projectile, repository);
 
-        // Create jenkins config
+        // Create jenkins config map. This config map stores information related
+        // to build. It is used by Jenkins.
         openShiftSteps.createJenkinsConfigMap(projectile, repository);
 
         // Trigger the build in Openshift
@@ -100,6 +98,10 @@ public class OsioImportMissionControl implements MissionControl<OsioImportProjec
         // Create Codebase in WIT
         final String cheStack = buildConfig.getMetadata().getAnnotations().get(Annotations.CHE_STACK);
         witSteps.createCodebase(projectile, cheStack, repository);
+
+        // Create webhook. This step should ALWAYS be at the end so that the
+        // initial commit doesn't trigger build.
+        gitSteps.createWebHooks(projectile, repository);
 
         return ImmutableBoom.builder()
                 .createdRepository(repository)

--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioImportMissionControl.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioImportMissionControl.java
@@ -94,6 +94,9 @@ public class OsioImportMissionControl implements MissionControl<OsioImportProjec
         // Create jenkins config
         openShiftSteps.createJenkinsConfigMap(projectile, repository);
 
+        // Trigger the build in Openshift
+        openShiftSteps.triggerBuild(projectile);
+
         // Create Codebase in WIT
         final String cheStack = buildConfig.getMetadata().getAnnotations().get(Annotations.CHE_STACK);
         witSteps.createCodebase(projectile, cheStack, repository);

--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioLaunchMissionControl.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioLaunchMissionControl.java
@@ -78,13 +78,11 @@ public class OsioLaunchMissionControl implements MissionControl<OsioProjectileCo
 
         final BuildConfig buildConfig = openShiftSteps.createBuildConfig(projectile, repository);
 
-        // Create webhook before push
-        gitSteps.createWebHooks(projectile, repository);
-
         // Push code after so that push event will trigger build
         gitSteps.pushToGitRepository(projectile, repository);
 
-        // Create jenkins config
+        // Create jenkins config map. This config map stores information related
+        // to build. It is used by Jenkins.
         openShiftSteps.createJenkinsConfigMap(projectile, repository);
 
         // Trigger the build in Openshift
@@ -93,6 +91,10 @@ public class OsioLaunchMissionControl implements MissionControl<OsioProjectileCo
         // Create Codebase in WIT
         final String cheStack = buildConfig.getMetadata().getAnnotations().get(Annotations.CHE_STACK);
         witSteps.createCodebase(projectile, cheStack, repository);
+
+        // Create webhook. This step should ALWAYS be at the end so that the
+        // initial commit doesn't trigger build.
+        gitSteps.createWebHooks(projectile, repository);
 
         return ImmutableBoom.builder()
                 .createdRepository(repository)

--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioLaunchMissionControl.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/OsioLaunchMissionControl.java
@@ -87,6 +87,9 @@ public class OsioLaunchMissionControl implements MissionControl<OsioProjectileCo
         // Create jenkins config
         openShiftSteps.createJenkinsConfigMap(projectile, repository);
 
+        // Trigger the build in Openshift
+        openShiftSteps.triggerBuild(projectile);
+
         // Create Codebase in WIT
         final String cheStack = buildConfig.getMetadata().getAnnotations().get(Annotations.CHE_STACK);
         witSteps.createCodebase(projectile, cheStack, repository);

--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/steps/OpenShiftSteps.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/steps/OpenShiftSteps.java
@@ -165,6 +165,14 @@ public class OpenShiftSteps {
         return cm;
     }
 
+    public void triggerBuild(OsioProjectile projectile) {
+        //TODO remove this call (the trigger build should already done by the webhook) and change the countdown latch to 1 in OsioStatusClientEndpoint
+        String namespace = tenant.getDefaultUserNamespace().getName();
+        openShiftService.triggerBuild(projectile.getOpenShiftProjectName(), namespace);
+
+        projectile.getEventConsumer().accept(new StatusMessageEvent(projectile.getId(), OPENSHIFT_PIPELINE));
+    }
+
     private BuildConfig createBuildConfigObject(OsioProjectile projectile, GitRepository repository) {
         String gitUrl = repository.getGitCloneUri().toString();
 

--- a/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/steps/OpenShiftSteps.java
+++ b/addons/osio-addon/src/main/java/io/fabric8/launcher/osio/steps/OpenShiftSteps.java
@@ -166,7 +166,6 @@ public class OpenShiftSteps {
     }
 
     public void triggerBuild(OsioProjectile projectile) {
-        //TODO remove this call (the trigger build should already done by the webhook) and change the countdown latch to 1 in OsioStatusClientEndpoint
         String namespace = tenant.getDefaultUserNamespace().getName();
         openShiftService.triggerBuild(projectile.getOpenShiftProjectName(), namespace);
 

--- a/services/openshift-service-api/src/main/java/io/fabric8/launcher/service/openshift/api/OpenShiftService.java
+++ b/services/openshift-service-api/src/main/java/io/fabric8/launcher/service/openshift/api/OpenShiftService.java
@@ -122,5 +122,7 @@ public interface OpenShiftService {
 
     void updateConfigMap(String configName, String namespace, Map<String, String> data);
 
+    void triggerBuild(String projectName, String namespace);
+
     void applyBuildConfig(BuildConfig buildConfig, String namespace);
 }

--- a/web/src/test/java/io/fabric8/launcher/web/endpoints/osio/OsioImportEndpointIT.java
+++ b/web/src/test/java/io/fabric8/launcher/web/endpoints/osio/OsioImportEndpointIT.java
@@ -191,13 +191,11 @@ public class OsioImportEndpointIT {
         } catch (final Exception e) {
             LOG.log(Level.SEVERE, "Could not delete jenkins config map in namespace " + defaultNamespace + " named " + gitOwner, e);
         }
-        if (space != null) {
-            try {
-                getWitClient().deleteSpace(space.getId());
-                LOG.info("Deleted space " + space.getId() + " named " + space.getName());
-            } catch (final Exception e) {
-                LOG.log(Level.SEVERE, "Could not delete space " + space.getId() + " named " + space.getName(), e);
-            }
+        try {
+            getWitClient().deleteSpace(space.getId());
+            LOG.info("Deleted space " + space.getId() + " named " + space.getName());
+        } catch (final Exception e) {
+            LOG.log(Level.SEVERE, "Could not delete space " + space.getId() + " named " + space.getName(), e);
         }
     }
 

--- a/web/src/test/java/io/fabric8/launcher/web/endpoints/osio/OsioLaunchEndpointIT.java
+++ b/web/src/test/java/io/fabric8/launcher/web/endpoints/osio/OsioLaunchEndpointIT.java
@@ -237,13 +237,11 @@ public class OsioLaunchEndpointIT {
         } catch (final Exception e) {
             LOG.log(Level.SEVERE, "Could not delete jenkins config map in namespace " + defaultNamespace + " named " + gitOwner, e);
         }
-        if (space != null) {
-            try {
-                getWitClient().deleteSpace(space.getId());
-                LOG.info("Deleted space " + space.getId() + " named " + space.getName());
-            } catch (final Exception e) {
-                LOG.log(Level.SEVERE, "Could not delete space " + space.getId() + " named " + space.getName(), e);
-            }
+        try {
+            getWitClient().deleteSpace(space.getId());
+            LOG.info("Deleted space " + space.getId() + " named " + space.getName());
+        } catch (final Exception e) {
+            LOG.log(Level.SEVERE, "Could not delete space " + space.getId() + " named " + space.getName(), e);
         }
     }
 

--- a/web/src/test/java/io/fabric8/launcher/web/endpoints/osio/OsioStatusClientEndpoint.java
+++ b/web/src/test/java/io/fabric8/launcher/web/endpoints/osio/OsioStatusClientEndpoint.java
@@ -18,7 +18,7 @@ public class OsioStatusClientEndpoint {
 
     private static final Logger LOG = Logger.getLogger(OsioStatusClientEndpoint.class.getName());
 
-    private final CountDownLatch latch = new CountDownLatch(1);
+    private final CountDownLatch latch = new CountDownLatch(2);
     private boolean githubPushed = false;
 
     private boolean codebaseCreated;


### PR DESCRIPTION
When a new project is created, two builds are triggered (not always because of a race condition). See openshiftio/openshift.io#3742
1. Because of webhook. We setup webhook before initial commit and that triggers one build (This build doesn't always work because **there is race condition between the config map and the webhook event** @hrishin found this out.)
2. Because of manual trigger build. (this build always work)

In 3001505 we removed the manual build trigger and as a result we had openshiftio/openshift.io#4752 . openshiftio/openshift.io#4752 shows that we have a race condition between the first webhook event and the config map that stores the Jenkins config.

This PR changes the sequence of events so that **we ALWAYS get ONE build**.
The new sequence looks like
1. Create Repository
2. Push changes to repository
3. Push Jenkins Config Map (this should be pushed before the webhook is setup. The config map stores information about Jenkins job that should be triggered on webhook event)
4. Trigger build manually. This will trigger the initial build
5. Setup the webhook on github. This step should always be at the end. This ensures only one build is triggered.

This PR should fix openshiftio/openshift.io#4752 and openshiftio/openshift.io#3742