### PR TITLE
feat(git): Using Failsafe library for retrying operations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
 
     <version.activemq.artemis>2.6.4</version.activemq.artemis>
     <version.httpclient>4.5.7</version.httpclient>
+    <version.failsafe>2.0.1</version.failsafe>
     <version.github.api>1.95</version.github.api>
     <version.jgit>5.2.1.201812262042-r</version.jgit>
     <version.jwt>3.7.0</version.jwt>
@@ -302,6 +303,11 @@
         <groupId>org.glassfish.web</groupId>
         <artifactId>javax.el</artifactId>
         <version>${version.glassfish.javax.el}</version>
+      </dependency>
+      <dependency>
+        <groupId>net.jodah</groupId>
+        <artifactId>failsafe</artifactId>
+        <version>${version.failsafe}</version>
       </dependency>
     </dependencies>
 

--- a/services/git-service-impl/pom.xml
+++ b/services/git-service-impl/pom.xml
@@ -31,7 +31,10 @@
       <groupId>org.eclipse.jgit</groupId>
       <artifactId>org.eclipse.jgit</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>net.jodah</groupId>
+      <artifactId>failsafe</artifactId>
+    </dependency>
     <!-- Test dependencies -->
     <dependency>
       <groupId>io.fabric8.launcher</groupId>


### PR DESCRIPTION
Failsafe is a lightweight, zero-dependency library for handling failures in Java 8+, with a concise API for handling everyday use cases and the flexibility to handle everything else.
It works by wrapping executable logic with one or more resilience policies, which can be combined and composed as needed.

https://github.com/jhalterman/failsafe