### PR TITLE
Make ClusterVerified inner class static

### DIFF
--- a/web/src/main/java/io/fabric8/launcher/web/endpoints/OpenShiftEndpoint.java
+++ b/web/src/main/java/io/fabric8/launcher/web/endpoints/OpenShiftEndpoint.java
@@ -103,7 +103,7 @@ public class OpenShiftEndpoint {
     /**
      * Used in OpenShiftEndpoint#getSupportedOpenShiftClusters
      */
-    private class ClusterVerified {
+    private static class ClusterVerified {
 
         private ClusterVerified(OpenShiftCluster cluster) {
             this.connected = true;


### PR DESCRIPTION
@gastaldi I improved things in Quarkus but the root of the issue was this missing status, which brought a loooot of unwanted classes as we were trying to mark everything accessible to the Resource class.

Quarkus PR to follow to fix the remaining things.